### PR TITLE
Gitignore is updated and vscode files are deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,10 @@ artifacts/
 # StyleCop
 StyleCopReport.xml
 
+# Files built by Jetbrains Rider
+.idea
+
+
 # Files built by Visual Studio
 *_i.c
 *_p.c
@@ -95,6 +99,7 @@ StyleCopReport.xml
 *.pidb
 *.svclog
 *.scc
+.vscode/
 
 # Chutzpah Test files
 _Chutzpah*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "files.associations": {
-        "array": "cpp",
-        "utility": "cpp"
-    },
-    "C_Cpp.default.cppStandard": "c++20"
-}


### PR DESCRIPTION
in order to not download developer spesific vscode and jetbrains rider files vscode and .idea is added to gitignore and vscode file is deleted from the repository.