### PR TITLE
[fix] #14 fix server thread safety errors

### DIFF
--- a/PlanetaMatchMakerServer/source/async/timer.hpp
+++ b/PlanetaMatchMakerServer/source/async/timer.hpp
@@ -25,8 +25,12 @@ namespace pgl {
 
 		const auto finish_timer = [&timer, is_operation_finished] {
 			if (!is_operation_finished->exchange(true, std::memory_order_acq_rel)) {
-				boost::system::error_code ignored_error;
-				timer.cancel(ignored_error);
+				try {
+					static_cast<void>(timer.cancel());
+				}
+				catch (const boost::system::system_error&) {
+					// Match the old cancel(error_code) behavior by ignoring cancellation errors.
+				}
 			}
 		};
 

--- a/PlanetaMatchMakerServer/source/async/timer.hpp
+++ b/PlanetaMatchMakerServer/source/async/timer.hpp
@@ -1,31 +1,41 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <functional>
+#include <memory>
 
 #include <boost/asio.hpp>
 
 namespace pgl {
+	// The socket executor must serialize this timer handler with socket operations, normally by constructing the socket
+	// with a strand. This keeps socket.cancel() ordered with the yielding async operation.
 	template <class TProtocol, typename... TimeParams>
 	void execute_socket_timed_async_operation(boost::asio::basic_socket<TProtocol>& socket,
 		const std::chrono::duration<TimeParams...>& time, std::function<void()>&& proc) {
 		boost::asio::steady_timer timer(socket.get_executor());
 		timer.expires_after(time);
-		auto is_timer_canceled = std::make_shared<bool>(false);
-		timer.async_wait([&socket, is_timer_canceled](const boost::system::error_code& error_code) {
-			if (!error_code && !*is_timer_canceled) { socket.cancel(); }
+		auto is_operation_finished = std::make_shared<std::atomic_bool>(false);
+		timer.async_wait([&socket, is_operation_finished](const boost::system::error_code& error_code) {
+			if (!error_code && !is_operation_finished->exchange(true, std::memory_order_acq_rel)) {
+				boost::system::error_code ignored_error;
+				socket.cancel(ignored_error);
+			}
 		});
 
-		try { proc(); }
-		catch (const boost::system::system_error& e) {
-			if (e.code() != boost::asio::error::operation_aborted) {
-				*is_timer_canceled = true;
-				timer.cancel();
+		const auto finish_timer = [&timer, is_operation_finished] {
+			if (!is_operation_finished->exchange(true, std::memory_order_acq_rel)) {
+				boost::system::error_code ignored_error;
+				timer.cancel(ignored_error);
 			}
+		};
+
+		try { proc(); }
+		catch (const boost::system::system_error&) {
+			finish_timer();
 			throw;
 		}
 
-		*is_timer_canceled = true;
-		timer.cancel();
+		finish_timer();
 	}
 }

--- a/PlanetaMatchMakerServer/source/data/thread_safe_data_container.hpp
+++ b/PlanetaMatchMakerServer/source/data/thread_safe_data_container.hpp
@@ -6,6 +6,7 @@
 #include <shared_mutex>
 #include <functional>
 #include <optional>
+#include <utility>
 #include <vector>
 #include <algorithm>
 
@@ -123,6 +124,11 @@ namespace pgl {
 		using id_type = member_variable_pointer_variable_t<IdMemberVariable>;
 		using id_param_type = typename boost::call_traits<id_type>::param_type;
 		using data_param_type = typename boost::call_traits<Data>::param_type;
+
+		struct search_result final {
+			std::vector<Data> data;
+			size_t total_count;
+		};
 
 		/**
 		 * Add or update data.
@@ -288,18 +294,33 @@ namespace pgl {
 		[[nodiscard]] std::vector<Data> search(
 			std::function<bool(data_param_type, data_param_type)>&& compare_function,
 			std::function<bool(data_param_type)>&& filter_function) const {
-			std::vector<Data> data;
+			auto result = search_with_total(std::move(compare_function), std::move(filter_function));
+			return std::move(result.data);
+		}
+
+		/**
+		 * Search data by filter and return sorted result with total count from the same locked snapshot.
+		 *
+		 * @param compare_function A function used to sort.
+		 * @param filter_function A function used to filter.
+		 * @return A list of data and the total number of data at the time the list was collected.
+		 */
+		[[nodiscard]] search_result search_with_total(
+			std::function<bool(data_param_type, data_param_type)>&& compare_function,
+			std::function<bool(data_param_type)>&& filter_function) const {
+			search_result result;
 			{
 				std::shared_lock lock(mutex_);
-				data.reserve(data_map_.size());
+				result.total_count = data_map_.size();
+				result.data.reserve(result.total_count);
 				for (auto&& pair : data_map_) {
 					if (const auto data_elem = pair.second.load(); filter_function(data_elem)) {
-						data.push_back(data_elem);
+						result.data.push_back(data_elem);
 					}
 				}
 			}
-			std::sort(data.begin(), data.end(), compare_function);
-			return data;
+			std::sort(result.data.begin(), result.data.end(), compare_function);
+			return result;
 		}
 
 		/**

--- a/PlanetaMatchMakerServer/source/data/thread_safe_data_container.hpp
+++ b/PlanetaMatchMakerServer/source/data/thread_safe_data_container.hpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <functional>
+#include <optional>
 #include <vector>
 #include <algorithm>
 
@@ -161,18 +162,7 @@ namespace pgl {
 		id_type assign_id_and_add(Data&& data,
 			std::function<id_type()>&& random_id_generator = generate_random_id<id_type>) {
 			std::lock_guard lock(mutex_);
-
-			id_type id{};
-			do { id = random_id_generator(); }
-			while (data_map_.contains(id));
-			data.*IdMemberVariable = id;
-
-			// Check if unique because ensure id of passed data is not duplicate existing id
-			if (!unique_variables_.is_unique(data)) { throw unique_variable_duplication_error(); }
-
-			auto&& [it,_] = data_map_.emplace(id, data);
-			unique_variables_.add_or_update_variables(it->second);
-			return id;
+			return assign_id_and_add_impl(data, random_id_generator);
 		}
 
 		/**
@@ -189,6 +179,36 @@ namespace pgl {
 		}
 
 		/**
+		 * Add new data with automatically assigned ID only if the current size is below max_size.
+		 *
+		 * @param data Data of rvalue reference
+		 * @param max_size Maximum number of data allowed in this container.
+		 * @param random_id_generator (optional) A functions to generate new ID. In default, built-in random value generator will be used.
+		 * @return An ID assigned to new data. std::nullopt if the container already reached max_size.
+		 * @throw unique_variable_duplication_error Unique member variable is duplicated.
+		 */
+		std::optional<id_type> try_assign_id_and_add(Data&& data, const size_t max_size,
+			std::function<id_type()>&& random_id_generator = generate_random_id<id_type>) {
+			std::lock_guard lock(mutex_);
+			if (data_map_.size() >= max_size) { return std::nullopt; }
+			return assign_id_and_add_impl(data, random_id_generator);
+		}
+
+		/**
+		 * Add new data with automatically assigned ID only if the current size is below max_size.
+		 *
+		 * @param data Data to add.
+		 * @param max_size Maximum number of data allowed in this container.
+		 * @param random_id_generator (optional) A functions to generate new ID. In default, built-in random value generator will be used.
+		 * @return An ID assigned to new data. std::nullopt if the container already reached max_size.
+		 * @throw unique_variable_duplication_error Unique member variable is duplicated.
+		 */
+		std::optional<id_type> try_assign_id_and_add(const Data& data, const size_t max_size,
+			std::function<id_type()>&& random_id_generator = generate_random_id<id_type>) {
+			return try_assign_id_and_add(Data{data}, max_size, std::move(random_id_generator));
+		}
+
+		/**
 		 * Get data by ID.
 		 * 
 		 * @param id ID to get data.
@@ -198,6 +218,64 @@ namespace pgl {
 		[[nodiscard]] Data get(id_param_type id) const {
 			std::shared_lock lock(mutex_);
 			return data_map_.at(id).load();
+		}
+
+		/**
+		 * Get data by ID if it exists.
+		 *
+		 * @param id ID to get data.
+		 * @return Data which has passed ID. std::nullopt if a data with passed ID does not exist.
+		 */
+		[[nodiscard]] std::optional<Data> try_get(id_param_type id) const {
+			std::shared_lock lock(mutex_);
+			const auto it = data_map_.find(id);
+			if (it == data_map_.end()) { return std::nullopt; }
+			return it->second.load();
+		}
+
+		/**
+		 * Update existing data under one exclusive lock.
+		 *
+		 * @param id ID to update data.
+		 * @param update_function A function to update the copied data. Do not call this container from it.
+		 * @return Updated data. std::nullopt if a data with passed ID does not exist.
+		 * @throw unique_variable_duplication_error Unique member variable is duplicated.
+		 */
+		template <typename UpdateFunction>
+		std::optional<Data> try_update(id_param_type id, UpdateFunction&& update_function) {
+			std::lock_guard lock(mutex_);
+			const auto it = data_map_.find(id);
+			if (it == data_map_.end()) { return std::nullopt; }
+
+			auto data = it->second.load();
+			update_function(data);
+			data.*IdMemberVariable = id;
+			if (!unique_variables_.is_unique(data)) { throw unique_variable_duplication_error(); }
+
+			it->second.store(data);
+			unique_variables_.add_or_update_variables(data);
+			return data;
+		}
+
+		/**
+		 * Remove existing data under one exclusive lock if remove_function allows it.
+		 *
+		 * @param id ID to remove data.
+		 * @param remove_function A function to check the copied data. Do not call this container from it.
+		 * @return Removed data. std::nullopt if a data with passed ID does not exist or remove_function returns false.
+		 */
+		template <typename RemoveFunction>
+		std::optional<Data> try_remove_if(id_param_type id, RemoveFunction&& remove_function) {
+			std::lock_guard lock(mutex_);
+			const auto it = data_map_.find(id);
+			if (it == data_map_.end()) { return std::nullopt; }
+
+			const auto data = it->second.load();
+			if (!remove_function(data)) { return std::nullopt; }
+
+			unique_variables_.remove_variables(id);
+			data_map_.erase(it);
+			return data;
 		}
 
 		/**
@@ -284,5 +362,19 @@ namespace pgl {
 		mutable std::shared_mutex mutex_;
 
 		static id_type get_id(const data_param_type data) { return data.*IdMemberVariable; }
+
+		id_type assign_id_and_add_impl(Data& data, const std::function<id_type()>& random_id_generator) {
+			id_type id{};
+			do { id = random_id_generator(); }
+			while (data_map_.contains(id));
+			data.*IdMemberVariable = id;
+
+			// Check if unique because ensure id of passed data is not duplicate existing id
+			if (!unique_variables_.is_unique(data)) { throw unique_variable_duplication_error(); }
+
+			auto&& [it,_] = data_map_.emplace(id, data);
+			unique_variables_.add_or_update_variables(it->second);
+			return id;
+		}
 	};
 }

--- a/PlanetaMatchMakerServer/source/data/thread_safe_data_container.hpp
+++ b/PlanetaMatchMakerServer/source/data/thread_safe_data_container.hpp
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 #include <atomic>
+#include <mutex>
 #include <shared_mutex>
 #include <functional>
 #include <vector>
@@ -52,7 +53,16 @@ namespace pgl {
 		 *
 		 * @param data A data to add or update.
 		 */
-		void add_or_update_variables(const Data& data) { data_.emplace(data); }
+		void add_or_update_variables(const Data& data) {
+			auto& id_index = data_.template get<0>();
+			const auto it = id_index.find(data.*IdMemberVariable);
+			if (it == id_index.end()) {
+				data_.emplace(data);
+				return;
+			}
+
+			id_index.replace(it, data);
+		}
 
 		/**
 		 * Remove data with ID.
@@ -122,12 +132,12 @@ namespace pgl {
 		 */
 		bool add_or_update(Data&& data) {
 			const auto id = get_id(data);
-			std::shared_lock lock(mutex_);
+			std::lock_guard lock(mutex_);
 
 			if (!unique_variables_.is_unique(data)) { throw unique_variable_duplication_error(); }
 
 			auto&& [it, is_added] = data_map_.insert_or_assign(id, data);
-			unique_variables_.add_or_update_variables(it->second);
+			unique_variables_.add_or_update_variables(it->second.load());
 			return is_added;
 		}
 
@@ -262,7 +272,11 @@ namespace pgl {
 		 *
 		 * @return The number of data.
 		 */
-		[[nodiscard]] size_t size() const { return data_map_.size(); }
+		[[nodiscard]] size_t size() const {
+			// Reading unordered_map::size can race with writers, so protect it like other read operations.
+			std::shared_lock lock(mutex_);
+			return data_map_.size();
+		}
 
 	private:
 		std::unordered_map<id_type, std::atomic<Data>> data_map_;

--- a/PlanetaMatchMakerServer/source/logger/log.cpp
+++ b/PlanetaMatchMakerServer/source/logger/log.cpp
@@ -1,5 +1,6 @@
 #include <unordered_map>
 #include <algorithm>
+#include <mutex>
 
 #include "log.hpp"
 
@@ -8,30 +9,37 @@ using namespace boost;
 using namespace minimal_serializer;
 
 namespace pgl {
+	static mutex logger_registry_mutex;
 	static mutex output_mutex;
 	std::vector<std::unique_ptr<logger>> loggers;
 	bool are_all_loggers_thread_safe = true;
 
 	void add_logger(std::unique_ptr<logger>&& logger) {
+		lock_guard lock(logger_registry_mutex);
 		are_all_loggers_thread_safe &= logger->is_thread_safe();
 		loggers.push_back(std::move(logger));
 	}
 
 	void log_impl(const log_level level, string&& header, string&& message) {
 		std::vector<logger*> active_loggers;
-		active_loggers.reserve(loggers.size());
-		for (auto&& logger : loggers) {
-			// We filter logs by level in logger if logger supports log level filtering
-			// If not, judge there
-			if (logger->is_log_level_filtering_supported() || level >= logger->level_threshold()) {
-				active_loggers.push_back(logger.get());
+		bool all_loggers_thread_safe;
+		{
+			lock_guard lock(logger_registry_mutex);
+			all_loggers_thread_safe = are_all_loggers_thread_safe;
+			active_loggers.reserve(loggers.size());
+			for (auto&& logger : loggers) {
+				// We filter logs by level in logger if logger supports log level filtering.
+				// If not, judge there.
+				if (logger->is_log_level_filtering_supported() || level >= logger->level_threshold()) {
+					active_loggers.push_back(logger.get());
+				}
 			}
 		}
 
 		// do nothing if there are no active loggers to avoid cost of mutex lock
 		if (active_loggers.empty()) { return; }
 
-		if (are_all_loggers_thread_safe) {
+		if (all_loggers_thread_safe) {
 			for (auto&& logger : active_loggers) { logger->log(level, header, message); }
 		}
 		else {

--- a/PlanetaMatchMakerServer/source/logger/log.hpp
+++ b/PlanetaMatchMakerServer/source/logger/log.hpp
@@ -9,7 +9,8 @@ namespace pgl {
 	// convert string to log level thead safely. If str is invalid, throws std::out_of_range.
 	log_level string_to_log_level(const std::string& str);
 
-	// Add logger. (not thread safe)
+	// Add logger. This is safe to call while log functions may run.
+	// Added loggers are retained for the process lifetime.
 	void add_logger(std::unique_ptr<logger>&& logger);
 
 	// Implementation of thread safe log function.

--- a/PlanetaMatchMakerServer/source/message/message_handle_utilities.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handle_utilities.cpp
@@ -4,7 +4,7 @@ namespace pgl {
 	bool does_room_exist(const std::shared_ptr<message_handle_parameter> param,
 		const room_data_container& room_data_container, room_id_t room_id) {
 		// Check room existence
-		if (room_data_container.contains(room_id)) {
+		if (room_data_container.try_get(room_id).has_value()) {
 			log_with_endpoint(log_level::debug, param->socket.remote_endpoint(), "The room whose id is \"", room_id,
 				"\" exists.");
 			return true;

--- a/PlanetaMatchMakerServer/source/message/message_handler.hpp
+++ b/PlanetaMatchMakerServer/source/message/message_handler.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <exception>
+#include <functional>
+#include <utility>
+
 #include <boost/asio/spawn.hpp>
 
 #include "minimal_serializer/serializer.hpp"
@@ -25,6 +29,7 @@ namespace pgl {
 	struct message_handling_result {
 		std::vector<ReplyMessage> reply_bodies;
 		bool is_disconnect_required;
+		std::function<void()> on_reply_failure = {};
 	};
 
 	class no_reply final { };
@@ -59,13 +64,15 @@ namespace pgl {
 				message_error_code::ok,
 			};
 			std::vector<ReplyMessage> reply_bodies;
+			std::function<void()> on_reply_failure;
 			try {
 				// handle message
 				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Handle ",
 					header.message_type, " message.");
-				const auto result = handle_message(message, param);
+				auto result = handle_message(message, param);
 				is_disconnect_required = result.is_disconnect_required;
 				reply_bodies = std::move(result.reply_bodies);
+				on_reply_failure = std::move(result.on_reply_failure);
 				reply_header.error_code = message_error_code::ok;
 				disconnect_reason = "Disconnect due to message handling result.";
 			}
@@ -92,19 +99,31 @@ namespace pgl {
 
 			// reply message if required
 			if constexpr (!std::is_same_v<ReplyMessage, no_reply>) {
-				if (reply_bodies.empty()) {
-					log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Reply ",
-						header.message_type, " message without body (", get_packed_size<reply_message_header>(),
-						" bytes).");
-					send(param, reply_header);
-				}
-				else {
-					for (auto&& reply_body : reply_bodies) {
+				try {
+					if (reply_bodies.empty()) {
 						log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Reply ",
-							header.message_type, " message (", get_packed_size<reply_message_header, ReplyMessage>(),
+							header.message_type, " message without body (", get_packed_size<reply_message_header>(),
 							" bytes).");
-						send(param, reply_header, reply_body);
+						send(param, reply_header);
 					}
+					else {
+						for (auto&& reply_body : reply_bodies) {
+							log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Reply ",
+								header.message_type, " message (", get_packed_size<reply_message_header, ReplyMessage>(),
+								" bytes).");
+							send(param, reply_header, reply_body);
+						}
+					}
+				}
+				catch (...) {
+					if (on_reply_failure) {
+						try { on_reply_failure(); }
+						catch (const std::exception& e) {
+							log(log_level::error, "Failed to run reply failure cleanup: ", e.what());
+						}
+						catch (...) { log(log_level::error, "Failed to run reply failure cleanup."); }
+					}
+					throw;
 				}
 			}
 

--- a/PlanetaMatchMakerServer/source/message/message_handler_invoker.hpp
+++ b/PlanetaMatchMakerServer/source/message/message_handler_invoker.hpp
@@ -10,7 +10,7 @@
 #include "message_handle_parameter.hpp"
 
 namespace pgl {
-	// A container of message handler. This is not thread safe
+	// Registration is not thread safe. Message handling is read-only after registration.
 	class message_handler_invoker final : boost::noncopyable {
 	public:
 		using message_handler_generator_type = std::function<std::unique_ptr<message_handler>()>;

--- a/PlanetaMatchMakerServer/source/message/message_handlers/create_room_request_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/create_room_request_message_handler.cpp
@@ -37,14 +37,6 @@ namespace pgl {
 			throw client_error(client_error_code::client_already_hosting_room, false, error_message);
 		}
 
-		// Check if room count reached limit
-		if (room_data_container.size() == param->server_setting.common.max_room_count) {
-			const auto error_message = generate_string("Failed to create new room with player\"",
-				param->session_data.client_player_name().generate_full_name(),
-				"\" because room count reaches max.");
-			throw client_error(client_error_code::room_count_exceeds_limit, false, error_message);
-		}
-
 		try {
 			// Create requested room
 			const auto host_endpoint = endpoint::make_from_boost_endpoint(param->socket.remote_endpoint());
@@ -52,7 +44,7 @@ namespace pgl {
 			game_host_endpoint.port_number = message.port_number;
 			const auto is_public = message.password.length() == 0;
 			const room_data room_data{
-				{}, // assign in room_data_container.assign_id_and_add(room_data)
+				{}, // assign in room_data_container.try_assign_id_and_add(room_data, max_room_count)
 				param->session_data.client_player_name(),
 				(is_public ? room_setting_flag::public_room : room_setting_flag::none) |
 				room_setting_flag::open_room,
@@ -66,9 +58,16 @@ namespace pgl {
 				1
 			};
 
-			create_room_reply_message reply{
-				room_data_container.assign_id_and_add(room_data)
-			};
+			const auto room_id = room_data_container.try_assign_id_and_add(room_data,
+				param->server_setting.common.max_room_count);
+			if (!room_id.has_value()) {
+				const auto error_message = generate_string("Failed to create new room with player\"",
+					param->session_data.client_player_name().generate_full_name(),
+					"\" because room count reaches max.");
+				throw client_error(client_error_code::room_count_exceeds_limit, false, error_message);
+			}
+
+			create_room_reply_message reply{*room_id};
 
 			log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "New ",
 				is_public ? "public" : "private", " room for player \"",

--- a/PlanetaMatchMakerServer/source/message/message_handlers/join_room_request_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/join_room_request_message_handler.cpp
@@ -63,6 +63,12 @@ namespace pgl {
 			room_data.game_host_endpoint,
 			room_data.game_host_external_id
 		};
-		return {{reply}, true};
+		return {
+			{reply},
+			true,
+			[param, room_id = message.room_id] {
+				param->server_data.get_room_data_container().try_release_player_join_reservation(room_id);
+			}
+		};
 	}
 }

--- a/PlanetaMatchMakerServer/source/message/message_handlers/join_room_request_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/join_room_request_message_handler.cpp
@@ -11,9 +11,8 @@ namespace pgl {
 
 		const auto& room_data_container = param->server_data.get_room_data_container();
 
-		// Check room existence
-		parameter_validator.validate_room_existence(room_data_container, message.room_id);
-		const auto room_data = room_data_container.get(message.room_id);
+		// Check room existence and get the same snapshot.
+		const auto room_data = parameter_validator.get_existing_room(room_data_container, message.room_id);
 
 		// Check if connection establish mode matches
 		if (room_data.game_host_connection_establish_mode != message.connection_establish_mode) {

--- a/PlanetaMatchMakerServer/source/message/message_handlers/join_room_request_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/join_room_request_message_handler.cpp
@@ -1,4 +1,5 @@
 #include "join_room_request_message_handler.hpp"
+#include "room/room_data_container.hpp"
 #include "../message_parameter_validator.hpp"
 
 using namespace minimal_serializer;
@@ -9,41 +10,49 @@ namespace pgl {
 		const std::shared_ptr<message_handle_parameter> param) {
 		const message_parameter_validator parameter_validator(param);
 
-		const auto& room_data_container = param->server_data.get_room_data_container();
+		auto& rooms = param->server_data.get_room_data_container();
 
-		// Check room existence and get the same snapshot.
-		const auto room_data = parameter_validator.get_existing_room(room_data_container, message.room_id);
-
-		// Check if connection establish mode matches
-		if (room_data.game_host_connection_establish_mode != message.connection_establish_mode) {
-			// connection_establish_mode.others is not converted to string correctly in nameof++ so convert to string as int
-			const auto error_message = generate_string("Connection establish mode of client \"",
-				static_cast<uint32_t>(message.connection_establish_mode),
-				"\" doesn't match one of requested room \"",
-				static_cast<uint32_t>(room_data.game_host_connection_establish_mode), "\".");
-			throw client_error(client_error_code::room_connection_establish_mode_mismatch, false, error_message);
+		// Check room join conditions and reserve one player slot with the same locked snapshot.
+		const auto join_result = rooms.try_reserve_player_for_join(message.room_id,
+			message.connection_establish_mode, message.password);
+		if (join_result.result == room_data_container::join_room_result::room_not_found) {
+			parameter_validator.throw_room_not_found_error(message.room_id);
 		}
 
-		// Check if the room is open
-		if ((room_data.setting_flags & room_setting_flag::open_room) != room_setting_flag::open_room) {
-			const auto error_message = generate_string("Requested room \"", message.room_id, "\" is not opened.");
-			throw client_error(client_error_code::room_permission_denied, false, error_message);
-		}
+		const auto room_data = *join_result.room;
+		switch (join_result.result) {
+			case room_data_container::join_room_result::connection_establish_mode_mismatch: {
+				// connection_establish_mode.others is not converted to string correctly in nameof++ so convert to string as int
+				const auto error_message = generate_string("Connection establish mode of client \"",
+					static_cast<uint32_t>(message.connection_establish_mode),
+					"\" doesn't match one of requested room \"",
+					static_cast<uint32_t>(room_data.game_host_connection_establish_mode), "\".");
+				throw client_error(client_error_code::room_connection_establish_mode_mismatch, false, error_message);
+			}
 
-		// Check password if private room
-		if ((room_data.setting_flags & room_setting_flag::public_room) != room_setting_flag::public_room && room_data.
-			password != message.password) {
-			const auto error_message = generate_string("The password is wrong for requested room \"", message.room_id,
-				"\".");
-			throw client_error(client_error_code::room_password_wrong, false, error_message);
-		}
+			case room_data_container::join_room_result::room_closed: {
+				const auto error_message = generate_string("Requested room \"", message.room_id, "\" is not opened.");
+				throw client_error(client_error_code::room_permission_denied, false, error_message);
+			}
 
-		// Check player acceptable
-		if (room_data.current_player_count >= room_data.max_player_count) {
-			const auto error_message = generate_string("Requested room \"", message.room_id,
-				"\" is full of players (", room_data.current_player_count,
-				").");
-			throw client_error(client_error_code::room_full, false, error_message);
+			case room_data_container::join_room_result::password_wrong: {
+				const auto error_message = generate_string("The password is wrong for requested room \"", message.room_id,
+					"\".");
+				throw client_error(client_error_code::room_password_wrong, false, error_message);
+			}
+
+			case room_data_container::join_room_result::room_full: {
+				const auto error_message = generate_string("Requested room \"", message.room_id,
+					"\" is full of players (", room_data.current_player_count,
+					").");
+				throw client_error(client_error_code::room_full, false, error_message);
+			}
+
+			case room_data_container::join_room_result::accepted:
+				break;
+
+			case room_data_container::join_room_result::room_not_found:
+				parameter_validator.throw_room_not_found_error(message.room_id);
 		}
 
 		log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Requested room \"", message.room_id,

--- a/PlanetaMatchMakerServer/source/message/message_handlers/keep_alive_notice_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/keep_alive_notice_message_handler.cpp
@@ -3,5 +3,5 @@
 namespace pgl {
 	keep_alive_notice_message_handler::handle_return_t keep_alive_notice_message_handler::handle_message(
 		const keep_alive_notice_message& message [[maybe_unused]],
-		std::shared_ptr<message_handle_parameter> param) { return {{}, false}; }
+		std::shared_ptr<message_handle_parameter> param [[maybe_unused]]) { return {{}, false}; }
 }

--- a/PlanetaMatchMakerServer/source/message/message_handlers/list_room_request_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/list_room_request_message_handler.cpp
@@ -1,5 +1,7 @@
 #include "list_room_request_message_handler.hpp"
 
+#include <utility>
+
 #include "server/server_data.hpp"
 #include "utilities/checked_static_cast.hpp"
 #include "../message_parameter_validator.hpp"
@@ -19,11 +21,14 @@ namespace pgl {
 
 		// Generate room data list to send
 		std::vector<room_data> matched_data_list;
+		size_t total_room_count = 0;
 		try {
-			matched_data_list = room_data_container.search(message.sort_kind, message.search_target_flags,
+			auto search_result = room_data_container.search_with_total(message.sort_kind, message.search_target_flags,
 				message.search_full_name);
+			matched_data_list = std::move(search_result.data);
+			total_room_count = search_result.total_room_count;
 			log_with_endpoint(log_level::info, param->socket.remote_endpoint(), matched_data_list.size(),
-				" rooms are matched in ", room_data_container.size(), " rooms.");
+				" rooms are matched in ", total_room_count, " rooms.");
 		}
 		catch (out_of_range&) {
 			const auto error_message = generate_string("Indicated sort_kind \"",
@@ -33,7 +38,7 @@ namespace pgl {
 
 		// Prepare reply header
 		list_room_reply_message reply{};
-		reply.total_room_count = range_checked_static_cast<uint16_t>(room_data_container.size());
+		reply.total_room_count = range_checked_static_cast<uint16_t>(total_room_count);
 		reply.matched_room_count = range_checked_static_cast<uint16_t>(matched_data_list.size());
 		reply.reply_room_count = std::min(range_checked_static_cast<uint16_t>(
 				reply.matched_room_count <= message.start_index ? 0 : reply.matched_room_count - message.start_index),

--- a/PlanetaMatchMakerServer/source/message/message_handlers/update_room_status_notice_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/update_room_status_notice_message_handler.cpp
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "update_room_status_notice_message_handler.hpp"
 #include "session/session_data.hpp"
 #include "../message_parameter_validator.hpp"
@@ -13,49 +15,65 @@ namespace pgl {
 		// Check room group existence
 		auto& room_data_container = param->server_data.get_room_data_container();
 
-		// Check room existence
-		parameter_validator.validate_room_existence(room_data_container, message.room_id);
-		auto room_data = room_data_container.get(message.room_id);
+		const auto client_endpoint = endpoint::make_from_boost_endpoint(param->socket.remote_endpoint());
+		const auto validate_host = [&](const room_data& target_room_data) {
+			if (target_room_data.host_endpoint == client_endpoint) { return; }
 
-		// Check if the client is host of requested room
-		if (room_data.host_endpoint != endpoint::make_from_boost_endpoint(param->socket.remote_endpoint())) {
 			const auto error_message = generate_string("The client is not host of requested ",
-				room_data, ". Room host endpoint is ", room_data.host_endpoint.to_boost_endpoint(), ".");
+				target_room_data, ". Room host endpoint is ", target_room_data.host_endpoint.to_boost_endpoint(), ".");
 			throw client_error(client_error_code::room_permission_denied, false, error_message);
-		}
-
-		// Update current player count if need
-		if (message.is_current_player_count_changed) {
-			if (message.current_player_count > room_data.max_player_count) {
+		};
+		const auto validate_current_player_count = [&](const room_data& target_room_data) {
+			if (!message.is_current_player_count_changed) { return; }
+			if (message.current_player_count > target_room_data.max_player_count) {
 				const auto error_message = generate_string("New player count \"",
-					message.current_player_count, "\" exceeds max player count \"", room_data.max_player_count,
-					"\" for ", room_data, ".");
+					message.current_player_count, "\" exceeds max player count \"", target_room_data.max_player_count,
+					"\" for ", target_room_data, ".");
 				throw client_error(client_error_code::request_parameter_wrong, false, error_message);
 			}
+		};
+		const auto update_current_player_count_if_need = [&](room_data& target_room_data) {
+			validate_current_player_count(target_room_data);
+			if (message.is_current_player_count_changed) {
+				target_room_data.current_player_count = message.current_player_count;
+			}
+		};
 
-			room_data.current_player_count = message.current_player_count;
-		}
+		auto updated_room_data = std::optional<room_data>();
 
 		// Change status of requested room
 		switch (message.status) {
 			case update_room_status_notice_message::status::open:
-				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Open ", room_data, ".");
-				room_data.setting_flags |= room_setting_flag::open_room;
-				room_data_container.add_or_update(room_data);
+				updated_room_data = room_data_container.try_update(message.room_id, [&](auto& target_room_data) {
+					validate_host(target_room_data);
+					update_current_player_count_if_need(target_room_data);
+					target_room_data.setting_flags |= room_setting_flag::open_room;
+				});
+				if (!updated_room_data.has_value()) { parameter_validator.throw_room_not_found_error(message.room_id); }
+				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Open ", *updated_room_data, ".");
 				break;
 			case update_room_status_notice_message::status::close:
-				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Close ", room_data, ".");
-				room_data.setting_flags &= ~room_setting_flag::open_room;
-				room_data_container.add_or_update(room_data);
+				updated_room_data = room_data_container.try_update(message.room_id, [&](auto& target_room_data) {
+					validate_host(target_room_data);
+					update_current_player_count_if_need(target_room_data);
+					target_room_data.setting_flags &= ~room_setting_flag::open_room;
+				});
+				if (!updated_room_data.has_value()) { parameter_validator.throw_room_not_found_error(message.room_id); }
+				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Close ", *updated_room_data, ".");
 				break;
 			case update_room_status_notice_message::status::remove:
-				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Remove ", room_data, ".");
-				room_data_container.try_remove(room_data.room_id);
-				param->session_data.delete_hosting_room_id(room_data.room_id);
+				updated_room_data = room_data_container.try_remove_if(message.room_id, [&](const auto& target_room_data) {
+					validate_host(target_room_data);
+					validate_current_player_count(target_room_data);
+					return true;
+				});
+				if (!updated_room_data.has_value()) { parameter_validator.throw_room_not_found_error(message.room_id); }
+				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Remove ", *updated_room_data, ".");
+				param->session_data.delete_hosting_room_id(updated_room_data->room_id);
 				break;
 			default:
-				const auto error_message = generate_string("The new status \"", message.status, "\" for ", room_data,
-					" is invalid.");
+				const auto error_message = generate_string("The new status \"", message.status, "\" for room \"",
+					message.room_id, "\" is invalid.");
 				throw client_error(client_error_code::request_parameter_wrong, false, error_message);
 		}
 

--- a/PlanetaMatchMakerServer/source/message/message_handlers/update_room_status_notice_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/update_room_status_notice_message_handler.cpp
@@ -32,32 +32,29 @@ namespace pgl {
 				throw client_error(client_error_code::request_parameter_wrong, false, error_message);
 			}
 		};
-		const auto update_current_player_count_if_need = [&](room_data& target_room_data) {
-			validate_current_player_count(target_room_data);
-			if (message.is_current_player_count_changed) {
-				target_room_data.current_player_count = message.current_player_count;
-			}
-		};
-
 		auto updated_room_data = std::optional<room_data>();
 
 		// Change status of requested room
 		switch (message.status) {
 			case update_room_status_notice_message::status::open:
-				updated_room_data = room_data_container.try_update(message.room_id, [&](auto& target_room_data) {
-					validate_host(target_room_data);
-					update_current_player_count_if_need(target_room_data);
-					target_room_data.setting_flags |= room_setting_flag::open_room;
-				});
+				updated_room_data = room_data_container.try_update_with_host_reported_current_player_count(message.room_id,
+					message.is_current_player_count_changed, message.current_player_count,
+					[&](auto& target_room_data) {
+						validate_host(target_room_data);
+						validate_current_player_count(target_room_data);
+						target_room_data.setting_flags |= room_setting_flag::open_room;
+					});
 				if (!updated_room_data.has_value()) { parameter_validator.throw_room_not_found_error(message.room_id); }
 				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Open ", *updated_room_data, ".");
 				break;
 			case update_room_status_notice_message::status::close:
-				updated_room_data = room_data_container.try_update(message.room_id, [&](auto& target_room_data) {
-					validate_host(target_room_data);
-					update_current_player_count_if_need(target_room_data);
-					target_room_data.setting_flags &= ~room_setting_flag::open_room;
-				});
+				updated_room_data = room_data_container.try_update_with_host_reported_current_player_count(message.room_id,
+					message.is_current_player_count_changed, message.current_player_count,
+					[&](auto& target_room_data) {
+						validate_host(target_room_data);
+						validate_current_player_count(target_room_data);
+						target_room_data.setting_flags &= ~room_setting_flag::open_room;
+					});
 				if (!updated_room_data.has_value()) { parameter_validator.throw_room_not_found_error(message.room_id); }
 				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Close ", *updated_room_data, ".");
 				break;

--- a/PlanetaMatchMakerServer/source/message/message_parameter_validator.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_parameter_validator.cpp
@@ -1,6 +1,7 @@
 #include "message_parameter_validator.hpp"
 
 #include "client/client_errors.hpp"
+#include "logger/log.hpp"
 #include "server/server_setting.hpp"
 
 namespace pgl {
@@ -9,10 +10,24 @@ namespace pgl {
 
 	void message_parameter_validator::validate_room_existence(const room_data_container& room_data_container,
 		const room_id_t room_id, const bool is_continuable) const {
-		// Check room existence
-		if (does_room_exist(param_, room_data_container, room_id)) { return; }
+		static_cast<void>(get_existing_room(room_data_container, room_id, is_continuable));
+	}
 
-		// Throw room doesn't exist error
+	room_data message_parameter_validator::get_existing_room(const room_data_container& room_data_container,
+		const room_id_t room_id, const bool is_continuable) const {
+		if (const auto room_data = room_data_container.try_get(room_id)) {
+			log_with_endpoint(log_level::debug, param_->socket.remote_endpoint(), "The room whose id is \"", room_id,
+				"\" exists.");
+			return *room_data;
+		}
+
+		log_with_endpoint(log_level::error, param_->socket.remote_endpoint(), "The room whose id is \"", room_id,
+			"\" doesn't exist.");
+		throw_room_not_found_error(room_id, is_continuable);
+	}
+
+	void message_parameter_validator::throw_room_not_found_error(const room_id_t room_id,
+		const bool is_continuable) const {
 		const auto error_message = minimal_serializer::generate_string("The room with id \"", room_id,
 			"\" does not exist.");
 		throw client_error(client_error_code::room_not_found, !is_continuable, error_message);

--- a/PlanetaMatchMakerServer/source/message/message_parameter_validator.hpp
+++ b/PlanetaMatchMakerServer/source/message/message_parameter_validator.hpp
@@ -13,6 +13,13 @@ namespace pgl {
 		void validate_room_existence(const room_data_container& room_data_container, room_id_t room_id,
 			bool is_continuable = true) const;
 
+		// Get a room data if the room exists. If it doesn't exist, throw client error.
+		[[nodiscard]] room_data get_existing_room(const room_data_container& room_data_container, room_id_t room_id,
+			bool is_continuable = true) const;
+
+		// Throw a room not found client error.
+		[[noreturn]] void throw_room_not_found_error(room_id_t room_id, bool is_continuable = true) const;
+
 		// Check a port number is valid. If it is not valid, throw client error.
 		void validate_port_number(port_number_type port_number, bool is_continuable = true) const;
 

--- a/PlanetaMatchMakerServer/source/room/room_data_container.hpp
+++ b/PlanetaMatchMakerServer/source/room/room_data_container.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "data/thread_safe_data_container.hpp"
 #include "client/player_full_name.hpp"
 
@@ -12,9 +14,11 @@ namespace pgl {
 	{
 		{ t.contains(room_id_t()) } -> std::convertible_to<bool>;
 		{ t.get(room_id_t()) } -> std::convertible_to<room_data>;
+		{ t.try_get(room_id_t()) } -> std::convertible_to<std::optional<room_data>>;
 		{ t.size() } -> std::convertible_to<size_t>;
 		{ t.assign_id_and_add(room_data()) } -> std::convertible_to<room_id_t>;
 		{ t.assign_id_and_add(std::declval<room_data>()) } -> std::convertible_to<room_id_t>;
+		{ t.try_assign_id_and_add(room_data(), size_t()) } -> std::convertible_to<std::optional<room_id_t>>;
 		{
 			t.search(room_data_sort_kind(), room_search_target_flag(), player_full_name())
 		} -> std::convertible_to<std::vector<room_data>>;
@@ -48,6 +52,14 @@ namespace pgl {
 		[[nodiscard]] room_data get(id_param_type id) const { return container_.get(id); }
 
 		/**
+		 * Get a room data with specific ID if it exists.
+		 *
+		 * @param id An ID to get room data.
+		 * @return A room data. std::nullopt if the room does not exist.
+		 */
+		[[nodiscard]] std::optional<room_data> try_get(id_param_type id) const { return container_.try_get(id); }
+
+		/**
 		 * Get the number of room data.
 		 *
 		 * @return The number of room data.
@@ -71,6 +83,30 @@ namespace pgl {
 		 * @throw unique_variable_duplication_error Unique member variable is duplicate.
 		 */
 		room_id_t assign_id_and_add(const room_data& data) { return container_.assign_id_and_add(data); }
+
+		/**
+		 * Add new room data with ID assigned automatically only if the current room count is below max_size.
+		 *
+		 * @param data New room data rvalue reference.
+		 * @param max_size Maximum number of rooms allowed.
+		 * @return An ID assigned to new room data. std::nullopt if room count already reached max_size.
+		 * @throw unique_variable_duplication_error Unique member variable is duplicate.
+		 */
+		std::optional<room_id_t> try_assign_id_and_add(room_data&& data, const size_t max_size) {
+			return container_.try_assign_id_and_add(std::forward<room_data>(data), max_size);
+		}
+
+		/**
+		 * Add new room data with ID assigned automatically only if the current room count is below max_size.
+		 *
+		 * @param data New room data.
+		 * @param max_size Maximum number of rooms allowed.
+		 * @return An ID assigned to new room data. std::nullopt if room count already reached max_size.
+		 * @throw unique_variable_duplication_error Unique member variable is duplicate.
+		 */
+		std::optional<room_id_t> try_assign_id_and_add(const room_data& data, const size_t max_size) {
+			return container_.try_assign_id_and_add(data, max_size);
+		}
 
 		/**
 		 * Search room data which matches conditions.
@@ -126,12 +162,37 @@ namespace pgl {
 		bool add_or_update(const room_data& data) { return container_.add_or_update(data); }
 
 		/**
+		 * Update an existing room under one exclusive lock.
+		 *
+		 * @param id An ID of room data to update.
+		 * @param update_function A function to update copied room data.
+		 * @return Updated room data. std::nullopt if the room does not exist.
+		 * @throw unique_variable_duplication_error Unique member variable is duplicated.
+		*/
+		template <typename UpdateFunction>
+		std::optional<room_data> try_update(id_param_type id, UpdateFunction&& update_function) {
+			return container_.try_update(id, std::forward<UpdateFunction>(update_function));
+		}
+
+		/**
 		 * Remove room data with an ID.
 		 *
 		 * @param id An ID of room data to remove.
 		 * @return true if removed.
 		 */
 		bool try_remove(id_param_type id) { return container_.try_remove(id); }
+
+		/**
+		 * Remove room data with an ID under one exclusive lock if remove_function allows it.
+		 *
+		 * @param id An ID of room data to remove.
+		 * @param remove_function A function to check copied room data.
+		 * @return Removed room data. std::nullopt if the room does not exist or remove_function returns false.
+		 */
+		template <typename RemoveFunction>
+		std::optional<room_data> try_remove_if(id_param_type id, RemoveFunction&& remove_function) {
+			return container_.try_remove_if(id, std::forward<RemoveFunction>(remove_function));
+		}
 
 	private:
 		container_type container_;

--- a/PlanetaMatchMakerServer/source/room/room_data_container.hpp
+++ b/PlanetaMatchMakerServer/source/room/room_data_container.hpp
@@ -210,19 +210,6 @@ namespace pgl {
 		bool add_or_update(const room_data& data) { return add_or_update(room_data{data}); }
 
 		/**
-		 * Update an existing room under one exclusive lock.
-		 *
-		 * @param id An ID of room data to update.
-		 * @param update_function A function to update copied room data.
-		 * @return Updated room data. std::nullopt if the room does not exist.
-		 * @throw unique_variable_duplication_error Unique member variable is duplicated.
-		*/
-		template <typename UpdateFunction>
-		std::optional<room_data> try_update(id_param_type id, UpdateFunction&& update_function) {
-			return container_.try_update(id, std::forward<UpdateFunction>(update_function));
-		}
-
-		/**
 		 * Reserve one player slot for joining a room under one exclusive lock.
 		 *
 		 * @param id An ID of room data to join.
@@ -291,6 +278,8 @@ namespace pgl {
 
 		/**
 		 * Update a room and apply a player count reported by the host without dropping in-flight join reservations.
+		 *
+		 * Use this for room status changes so host reports and pending join reservations stay consistent.
 		 *
 		 * The server increments current_player_count before the joining client reaches the host. A host status notice
 		 * generated from an older snapshot must not erase that reservation, otherwise concurrent join requests can be

--- a/PlanetaMatchMakerServer/source/room/room_data_container.hpp
+++ b/PlanetaMatchMakerServer/source/room/room_data_container.hpp
@@ -339,12 +339,14 @@ namespace pgl {
 			const auto reservation_count = std::min<uint16_t>(stored_reservation_count,
 				target_room_data.current_player_count);
 			stored_reservation_count = static_cast<uint8_t>(reservation_count);
-			const auto previous_host_count = static_cast<uint16_t>(target_room_data.current_player_count) -
-				reservation_count;
+			const auto previous_host_count = static_cast<uint16_t>(
+				target_room_data.current_player_count - reservation_count);
 
 			if (reported_player_count > previous_host_count) {
+				const auto increased_host_count = static_cast<uint16_t>(
+					reported_player_count - previous_host_count);
 				const auto confirmed_count = std::min<uint16_t>(
-					reservation_count, reported_player_count - previous_host_count);
+					reservation_count, increased_host_count);
 				stored_reservation_count -= static_cast<uint8_t>(confirmed_count);
 			}
 

--- a/PlanetaMatchMakerServer/source/room/room_data_container.hpp
+++ b/PlanetaMatchMakerServer/source/room/room_data_container.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <algorithm>
+#include <mutex>
 #include <optional>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -34,6 +37,7 @@ namespace pgl {
 	public:
 		using container_type = thread_safe_data_container<room_data, &room_data::room_id, &
 			room_data::host_player_full_name>;
+		using id_type = container_type::id_type;
 		using id_param_type = container_type::id_param_type;
 		using data_param_type = container_type::data_param_type;
 
@@ -188,7 +192,13 @@ namespace pgl {
 		 * @throw unique_variable_duplication_error Unique member variable is duplicated.
 		 * @return true if added.
 		*/
-		bool add_or_update(room_data&& data) { return container_.add_or_update(std::forward<room_data>(data)); }
+		bool add_or_update(room_data&& data) {
+			const auto id = data.room_id;
+			std::lock_guard lock(reservation_mutex_);
+			const auto result = container_.add_or_update(std::forward<room_data>(data));
+			reserved_player_count_map_.erase(id);
+			return result;
+		}
 
 		/**
 		 * Add or update room.
@@ -197,7 +207,7 @@ namespace pgl {
 		 * @throw unique_variable_duplication_error Unique member variable is duplicated.
 		 * @return true if added.
 		*/
-		bool add_or_update(const room_data& data) { return container_.add_or_update(data); }
+		bool add_or_update(const room_data& data) { return add_or_update(room_data{data}); }
 
 		/**
 		 * Update an existing room under one exclusive lock.
@@ -223,6 +233,7 @@ namespace pgl {
 		join_room_result_data try_reserve_player_for_join(id_param_type id,
 			const game_host_connection_establish_mode connection_establish_mode,
 			const room_password_t& password) {
+			std::lock_guard lock(reservation_mutex_);
 			auto result = join_room_result_data{ join_room_result::room_not_found, std::nullopt };
 			const auto updated_room_data = container_.try_update(id, [&](auto& target_room_data) {
 				if (target_room_data.game_host_connection_establish_mode != connection_establish_mode) {
@@ -246,8 +257,9 @@ namespace pgl {
 					return;
 				}
 
-				// Reserve capacity immediately. A later host status notice may overwrite this with the actual count.
+				// Reserve capacity immediately until a later host status notice confirms the joining player.
 				++target_room_data.current_player_count;
+				++reserved_player_count_map_[id];
 				result = { join_room_result::accepted, target_room_data };
 			});
 
@@ -257,12 +269,37 @@ namespace pgl {
 		}
 
 		/**
+		 * Update a room and apply a player count reported by the host without dropping in-flight join reservations.
+		 *
+		 * The server increments current_player_count before the joining client reaches the host. A host status notice
+		 * generated from an older snapshot must not erase that reservation, otherwise concurrent join requests can be
+		 * over-accepted.
+		 */
+		template <typename UpdateFunction>
+		std::optional<room_data> try_update_with_host_reported_current_player_count(id_param_type id,
+			const bool is_current_player_count_changed, const uint8_t host_current_player_count,
+			UpdateFunction&& update_function) {
+			std::lock_guard lock(reservation_mutex_);
+			return container_.try_update(id, [&](auto& target_room_data) {
+				update_function(target_room_data);
+				if (is_current_player_count_changed) {
+					apply_host_reported_current_player_count(id, target_room_data, host_current_player_count);
+				}
+			});
+		}
+
+		/**
 		 * Remove room data with an ID.
 		 *
 		 * @param id An ID of room data to remove.
 		 * @return true if removed.
 		 */
-		bool try_remove(id_param_type id) { return container_.try_remove(id); }
+		bool try_remove(id_param_type id) {
+			std::lock_guard lock(reservation_mutex_);
+			const auto result = container_.try_remove(id);
+			if (result) { reserved_player_count_map_.erase(id); }
+			return result;
+		}
 
 		/**
 		 * Remove room data with an ID under one exclusive lock if remove_function allows it.
@@ -273,10 +310,39 @@ namespace pgl {
 		 */
 		template <typename RemoveFunction>
 		std::optional<room_data> try_remove_if(id_param_type id, RemoveFunction&& remove_function) {
-			return container_.try_remove_if(id, std::forward<RemoveFunction>(remove_function));
+			std::lock_guard lock(reservation_mutex_);
+			auto result = container_.try_remove_if(id, std::forward<RemoveFunction>(remove_function));
+			if (result.has_value()) { reserved_player_count_map_.erase(id); }
+			return result;
 		}
 
 	private:
 		container_type container_;
+		std::unordered_map<id_type, uint8_t> reserved_player_count_map_;
+		mutable std::mutex reservation_mutex_;
+
+		void apply_host_reported_current_player_count(id_param_type id, room_data& target_room_data,
+			const uint8_t host_current_player_count) {
+			const auto reported_player_count = std::min<uint16_t>(host_current_player_count,
+				target_room_data.max_player_count);
+			auto& stored_reservation_count = reserved_player_count_map_[id];
+			const auto reservation_count = std::min<uint16_t>(stored_reservation_count,
+				target_room_data.current_player_count);
+			stored_reservation_count = static_cast<uint8_t>(reservation_count);
+			const auto previous_host_count = static_cast<uint16_t>(target_room_data.current_player_count) -
+				reservation_count;
+
+			if (reported_player_count > previous_host_count) {
+				const auto confirmed_count = std::min<uint16_t>(
+					reservation_count, reported_player_count - previous_host_count);
+				stored_reservation_count -= static_cast<uint8_t>(confirmed_count);
+			}
+
+			const auto effective_player_count = std::min<uint16_t>(
+				target_room_data.max_player_count,
+				reported_player_count + stored_reservation_count);
+			target_room_data.current_player_count = static_cast<uint8_t>(effective_player_count);
+			if (stored_reservation_count == 0) { reserved_player_count_map_.erase(id); }
+		}
 	};
 }

--- a/PlanetaMatchMakerServer/source/room/room_data_container.hpp
+++ b/PlanetaMatchMakerServer/source/room/room_data_container.hpp
@@ -269,6 +269,27 @@ namespace pgl {
 		}
 
 		/**
+		 * Release one in-flight join reservation if the join reply cannot be delivered to the joining client.
+		 *
+		 * A successful join reply transfers the reservation to the host confirmation flow, so this must only be called
+		 * when the server knows the join client did not receive the host endpoint.
+		 */
+		bool try_release_player_join_reservation(id_param_type id) {
+			std::lock_guard lock(reservation_mutex_);
+			auto is_released = false;
+			const auto updated_room_data = container_.try_update(id, [&](auto& target_room_data) {
+				const auto reservation_it = reserved_player_count_map_.find(id);
+				if (reservation_it == reserved_player_count_map_.end() || reservation_it->second == 0) { return; }
+
+				--reservation_it->second;
+				if (target_room_data.current_player_count > 0) { --target_room_data.current_player_count; }
+				if (reservation_it->second == 0) { reserved_player_count_map_.erase(reservation_it); }
+				is_released = true;
+			});
+			return updated_room_data.has_value() && is_released;
+		}
+
+		/**
 		 * Update a room and apply a player count reported by the host without dropping in-flight join reservations.
 		 *
 		 * The server increments current_player_count before the joining client reaches the host. A host status notice

--- a/PlanetaMatchMakerServer/source/room/room_data_container.hpp
+++ b/PlanetaMatchMakerServer/source/room/room_data_container.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <optional>
+#include <utility>
+#include <vector>
 
 #include "data/thread_safe_data_container.hpp"
 #include "client/player_full_name.hpp"
@@ -34,6 +36,25 @@ namespace pgl {
 			room_data::host_player_full_name>;
 		using id_param_type = container_type::id_param_type;
 		using data_param_type = container_type::data_param_type;
+
+		enum class join_room_result {
+			accepted,
+			room_not_found,
+			connection_establish_mode_mismatch,
+			room_closed,
+			password_wrong,
+			room_full
+		};
+
+		struct join_room_result_data final {
+			join_room_result result;
+			std::optional<room_data> room;
+		};
+
+		struct search_result final {
+			std::vector<room_data> data;
+			size_t total_room_count;
+		};
 
 		/**
 		 * Check if the room data exists with specific ID.
@@ -125,6 +146,23 @@ namespace pgl {
 		}
 
 		/**
+		 * Search room data and return the total room count from the same locked snapshot.
+		 *
+		 * @param sort_kind A kind of sort for the result list. A room data which exactly matches search_full_name is always located top whatever sort kind is.
+		 * @param search_target_flags A flags of condition to search rooms. Rooms whose status matches some more than or equals one flag will be returned.
+		 * @param search_full_name A room full name to search. Not only full name ("Bill#123") but also tag ("#123"), name ("Bill") or empty string are available.
+		 * @return A list of result room data and the total room count at the time the list was collected.
+		 * @throw std::out_of_range room_data_sort_kind is invalid.
+		 */
+		search_result search_with_total(const room_data_sort_kind sort_kind,
+			const room_search_target_flag search_target_flags,
+			const player_full_name& search_full_name) const {
+			auto result = container_.search_with_total(get_room_data_compare_function(sort_kind, search_full_name),
+				get_room_data_filter_function(search_target_flags, search_full_name));
+			return { std::move(result.data), result.total_count };
+		}
+
+		/**
 		 * Search room data which matches conditions with range.
 		 *
 		 * @param start_idx A start index of range.
@@ -172,6 +210,50 @@ namespace pgl {
 		template <typename UpdateFunction>
 		std::optional<room_data> try_update(id_param_type id, UpdateFunction&& update_function) {
 			return container_.try_update(id, std::forward<UpdateFunction>(update_function));
+		}
+
+		/**
+		 * Reserve one player slot for joining a room under one exclusive lock.
+		 *
+		 * @param id An ID of room data to join.
+		 * @param connection_establish_mode An expected way how to establish P2P connection.
+		 * @param password A password of the room. This is only referred when indicated room is private.
+		 * @return Join result and a room snapshot. Accepted result contains the updated snapshot.
+		 */
+		join_room_result_data try_reserve_player_for_join(id_param_type id,
+			const game_host_connection_establish_mode connection_establish_mode,
+			const room_password_t& password) {
+			auto result = join_room_result_data{ join_room_result::room_not_found, std::nullopt };
+			const auto updated_room_data = container_.try_update(id, [&](auto& target_room_data) {
+				if (target_room_data.game_host_connection_establish_mode != connection_establish_mode) {
+					result = { join_room_result::connection_establish_mode_mismatch, target_room_data };
+					return;
+				}
+
+				if ((target_room_data.setting_flags & room_setting_flag::open_room) != room_setting_flag::open_room) {
+					result = { join_room_result::room_closed, target_room_data };
+					return;
+				}
+
+				if ((target_room_data.setting_flags & room_setting_flag::public_room) != room_setting_flag::public_room &&
+					target_room_data.password != password) {
+					result = { join_room_result::password_wrong, target_room_data };
+					return;
+				}
+
+				if (target_room_data.current_player_count >= target_room_data.max_player_count) {
+					result = { join_room_result::room_full, target_room_data };
+					return;
+				}
+
+				// Reserve capacity immediately. A later host status notice may overwrite this with the actual count.
+				++target_room_data.current_player_count;
+				result = { join_room_result::accepted, target_room_data };
+			});
+
+			if (!updated_room_data.has_value()) { return result; }
+			if (result.result == join_room_result::accepted) { result.room = updated_room_data; }
+			return result;
 		}
 
 		/**

--- a/PlanetaMatchMakerServer/source/server/server.cpp
+++ b/PlanetaMatchMakerServer/source/server/server.cpp
@@ -1,4 +1,6 @@
 #include <boost/thread.hpp>
+#include <exception>
+#include <mutex>
 
 #include "server.hpp"
 
@@ -31,15 +33,27 @@ namespace pgl {
 
 		log(log_level::info, "Start ", server_setting_->common.thread, " threads.");
 
+		std::mutex exception_mutex;
+		std::exception_ptr first_exception;
 		thread_group thread_group;
 		for (auto i = 0u; i < server_setting_->common.thread; ++i) {
 			thread_group.create_thread([&]() {
-				server_thread server_thread(acceptor_, acceptor_mutex_, *server_data_, *server_setting_);
-				server_thread.start();
-				io_service_.run();
+				try {
+					server_thread server_thread(acceptor_, acceptor_mutex_, *server_data_, *server_setting_);
+					server_thread.start();
+					io_service_.run();
+				}
+				catch (...) {
+					{
+						std::lock_guard lock(exception_mutex);
+						if (!first_exception) { first_exception = std::current_exception(); }
+					}
+					io_service_.stop();
+				}
 			});
 		}
 
 		thread_group.join_all();
+		if (first_exception) { std::rethrow_exception(first_exception); }
 	}
 }

--- a/PlanetaMatchMakerServer/source/server/server.cpp
+++ b/PlanetaMatchMakerServer/source/server/server.cpp
@@ -34,7 +34,7 @@ namespace pgl {
 		thread_group thread_group;
 		for (auto i = 0u; i < server_setting_->common.thread; ++i) {
 			thread_group.create_thread([&]() {
-				server_thread server_thread(acceptor_, *server_data_, *server_setting_);
+				server_thread server_thread(acceptor_, acceptor_mutex_, *server_data_, *server_setting_);
 				server_thread.start();
 				io_service_.run();
 			});

--- a/PlanetaMatchMakerServer/source/server/server.hpp
+++ b/PlanetaMatchMakerServer/source/server/server.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 
 #include <boost/asio.hpp>
 #include <boost/noncopyable.hpp>
@@ -16,6 +17,7 @@ namespace pgl {
 	private:
 		boost::asio::io_context io_service_;
 		boost::asio::ip::tcp::acceptor acceptor_;
+		std::mutex acceptor_mutex_;
 		std::unique_ptr<server_data> server_data_;
 		std::unique_ptr<server_setting> server_setting_;
 	};

--- a/PlanetaMatchMakerServer/source/server/server_session.cpp
+++ b/PlanetaMatchMakerServer/source/server/server_session.cpp
@@ -25,9 +25,16 @@ namespace pgl {
 		server_data_(server_data),
 		server_setting_(server_setting),
 		message_handler_invoker_(message_handler_invoker),
-		socket_(acceptor.get_executor()) { }
+		strand_(asio::make_strand(acceptor.get_executor())),
+		socket_(strand_) { }
 
 	void server_session::start() {
+		asio::dispatch(strand_, [shared_this = shared_from_this()] {
+			shared_this->start_impl();
+		});
+	}
+
+	void server_session::start_impl() {
 		// Reset session
 		session_data_ = std::make_unique<session_data>();
 
@@ -35,16 +42,17 @@ namespace pgl {
 		const auto shared_this = shared_from_this();
 		log(log_level::debug, "Start to accept.");
 		{
-			// basic_socket_acceptor is unsafe for concurrent shared-object access, so serialize only accept initiation.
+			// Serialize accept initiation on the shared acceptor, then bind completion to this session strand.
 			std::lock_guard lock(acceptor_mutex_);
-			acceptor_.async_accept(socket_, [shared_this](const system::error_code& accept_error) {
-				shared_this->handle_accepted_connection(accept_error);
-			});
+			acceptor_.async_accept(socket_,
+				asio::bind_executor(strand_, [shared_this](const system::error_code& accept_error) {
+					shared_this->handle_accepted_connection(accept_error);
+				}));
 		}
 	}
 
 	void server_session::handle_accepted_connection(const system::error_code& accept_error) {
-		spawn(socket_.get_executor(), [shared_this=shared_from_this(), accept_error](asio::yield_context yield) {
+		spawn(strand_, [shared_this=shared_from_this(), accept_error](asio::yield_context yield) {
 			try {
 				try {
 					if (accept_error) {
@@ -112,6 +120,13 @@ namespace pgl {
 	}
 
 	void server_session::stop() {
+		// dispatch runs inline when already on this strand, preserving restart ordering.
+		asio::dispatch(strand_, [shared_this = shared_from_this()] {
+			shared_this->stop_impl();
+		});
+	}
+
+	void server_session::stop_impl() {
 		finalize();
 		socket_.close();
 	}
@@ -130,8 +145,10 @@ namespace pgl {
 
 	void server_session::restart() {
 		log(log_level::info, "Server session handler is restarted.");
-		stop();
-		start();
+		asio::dispatch(strand_, [shared_this = shared_from_this()] {
+			shared_this->stop_impl();
+			shared_this->start_impl();
+		});
 	}
 
 	void server_session::remove_hosting_room_if_need() const {

--- a/PlanetaMatchMakerServer/source/server/server_session.cpp
+++ b/PlanetaMatchMakerServer/source/server/server_session.cpp
@@ -1,4 +1,5 @@
 #include <boost/asio/spawn.hpp>
+#include <mutex>
 
 #include "message/message_handler_invoker.hpp"
 #include "message/messages.hpp"
@@ -17,9 +18,10 @@ using namespace boost;
 using namespace minimal_serializer;
 
 namespace pgl {
-	server_session::server_session(asio::ip::tcp::acceptor& acceptor, server_data& server_data,
-		const server_setting& server_setting, message_handler_invoker& message_handler_invoker):
+	server_session::server_session(asio::ip::tcp::acceptor& acceptor, std::mutex& acceptor_mutex,
+		server_data& server_data, const server_setting& server_setting, message_handler_invoker& message_handler_invoker):
 		acceptor_(acceptor),
+		acceptor_mutex_(acceptor_mutex),
 		server_data_(server_data),
 		server_setting_(server_setting),
 		message_handler_invoker_(message_handler_invoker),
@@ -30,11 +32,26 @@ namespace pgl {
 		session_data_ = std::make_unique<session_data>();
 
 		// Start connection
-		spawn(acceptor_.get_executor(), [shared_this=shared_from_this()](asio::yield_context yield) {
+		const auto shared_this = shared_from_this();
+		log(log_level::debug, "Start to accept.");
+		{
+			// basic_socket_acceptor is unsafe for concurrent shared-object access, so serialize only accept initiation.
+			std::lock_guard lock(acceptor_mutex_);
+			acceptor_.async_accept(socket_, [shared_this](const system::error_code& accept_error) {
+				shared_this->handle_accepted_connection(accept_error);
+			});
+		}
+	}
+
+	void server_session::handle_accepted_connection(const system::error_code& accept_error) {
+		spawn(socket_.get_executor(), [shared_this=shared_from_this(), accept_error](asio::yield_context yield) {
 			try {
-				log(log_level::debug, "Start to accept.");
 				try {
-					shared_this->acceptor_.async_accept(shared_this->socket_, yield);
+					if (accept_error) {
+						const auto extra_message = generate_string("Acception failed: ", accept_error.message());
+						throw server_session_error(extra_message);
+					}
+
 					shared_this->session_data_->set_remote_endpoint(
 						endpoint::make_from_boost_endpoint(
 							shared_this->socket_.remote_endpoint()));

--- a/PlanetaMatchMakerServer/source/server/server_session.cpp
+++ b/PlanetaMatchMakerServer/source/server/server_session.cpp
@@ -59,7 +59,7 @@ namespace pgl {
 	void server_session::handle_accepted_connection(const system::error_code& accept_error) {
 		if (is_stopping_.load(std::memory_order_acquire)) { return; }
 
-		spawn(strand_, [shared_this=shared_from_this(), accept_error](asio::yield_context yield) {
+		static_cast<void>(spawn(strand_, [shared_this=shared_from_this(), accept_error](asio::yield_context yield) {
 			try {
 				try {
 					if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
@@ -129,7 +129,7 @@ namespace pgl {
 				shared_this->stop();
 				throw;
 			}
-		});
+		}));
 	}
 
 	void server_session::stop() {

--- a/PlanetaMatchMakerServer/source/server/server_session.cpp
+++ b/PlanetaMatchMakerServer/source/server/server_session.cpp
@@ -1,5 +1,7 @@
 #include <boost/asio/spawn.hpp>
+#include <exception>
 #include <mutex>
+#include <utility>
 
 #include "message/message_handler_invoker.hpp"
 #include "message/messages.hpp"
@@ -19,12 +21,13 @@ using namespace minimal_serializer;
 
 namespace pgl {
 	server_session::server_session(asio::ip::tcp::acceptor& acceptor, std::mutex& acceptor_mutex,
-		server_data& server_data, const server_setting& server_setting, message_handler_invoker& message_handler_invoker):
+		server_data& server_data, const server_setting& server_setting,
+		std::shared_ptr<const message_handler_invoker> message_handler_invoker):
 		acceptor_(acceptor),
 		acceptor_mutex_(acceptor_mutex),
 		server_data_(server_data),
 		server_setting_(server_setting),
-		message_handler_invoker_(message_handler_invoker),
+		message_handler_invoker_(std::move(message_handler_invoker)),
 		strand_(asio::make_strand(acceptor.get_executor())),
 		socket_(strand_) { }
 
@@ -87,35 +90,40 @@ namespace pgl {
 				});
 
 				// Authenticate client
-				shared_this->message_handler_invoker_.handle_specific_message(message_type::authentication,
+				shared_this->message_handler_invoker_->handle_specific_message(message_type::authentication,
 					message_handler_param);
 
 				// Receive message
-				while (true) { shared_this->message_handler_invoker_.handle_message(message_handler_param); }
+				while (true) { shared_this->message_handler_invoker_->handle_message(message_handler_param); }
 			}
 			catch (const server_session_intended_disconnect_error& e) {
+				if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
 				log_with_endpoint(log_level::info,
 					shared_this->session_data_->remote_endpoint().to_boost_endpoint(),
 					"Intended disconnect: ", e);
 				shared_this->restart();
 			}
 			catch (const server_session_error& e) {
+				if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
 				// output log as info for session error because it is caused by external factors like disconnection by client and network error.
 				log_with_endpoint(log_level::info, shared_this->session_data_->remote_endpoint().to_boost_endpoint(),
 					e, " Disconnect the connection.");
 				shared_this->restart();
 			}
 			catch (const system::system_error& e) {
+				if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
 				log_with_endpoint(log_level::error, shared_this->session_data_->remote_endpoint().to_boost_endpoint(),
 					"Unhandled error: ", e, " Disconnect the connection: ");
 				shared_this->restart();
 			}
 			catch (const std::exception& e) {
+				if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
 				log_with_endpoint(log_level::error, shared_this->session_data_->remote_endpoint().to_boost_endpoint(),
 					typeid(e), ": ", e.what(), " Disconnect the connection.");
 				shared_this->restart();
 			}
 			catch (...) {
+				if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
 				log_with_endpoint(log_level::fatal, shared_this->session_data_->remote_endpoint().to_boost_endpoint(),
 					"Unknown error. Stop the server.");
 				shared_this->stop();
@@ -133,22 +141,29 @@ namespace pgl {
 	}
 
 	void server_session::stop_impl() {
-		if (session_data_) { finalize(); }
+		std::exception_ptr finalize_exception;
+		if (session_data_) {
+			const auto session_data = std::move(session_data_);
+			try { finalize(*session_data); }
+			catch (...) { finalize_exception = std::current_exception(); }
+		}
 
 		boost::system::error_code ignored_error;
 		socket_.close(ignored_error);
+
+		if (finalize_exception) { std::rethrow_exception(finalize_exception); }
 	}
 
-	void server_session::finalize() const {
+	void server_session::finalize(const session_data& session_data) const {
 		// Remove hosting room if exist
-		try { remove_hosting_room_if_need(); }
+		try { remove_hosting_room_if_need(session_data); }
 		catch (...) {
-			remove_player_full_name_if_need();
+			remove_player_full_name_if_need(session_data);
 			throw;
 		}
 
 		// Remove player name
-		remove_player_full_name_if_need();
+		remove_player_full_name_if_need(session_data);
 	}
 
 	void server_session::restart() {
@@ -160,21 +175,21 @@ namespace pgl {
 		});
 	}
 
-	void server_session::remove_hosting_room_if_need() const {
-		if (session_data_->is_hosting_room()) {
-			server_data_.get_room_data_container().try_remove(session_data_->hosting_room_id());
-			log_with_endpoint(log_level::info, session_data_->remote_endpoint().to_boost_endpoint(),
-				"Hosting room(ID: ", session_data_->hosting_room_id(), ") is removed.");
+	void server_session::remove_hosting_room_if_need(const session_data& session_data) const {
+		if (session_data.is_hosting_room()) {
+			server_data_.get_room_data_container().try_remove(session_data.hosting_room_id());
+			log_with_endpoint(log_level::info, session_data.remote_endpoint().to_boost_endpoint(),
+				"Hosting room(ID: ", session_data.hosting_room_id(), ") is removed.");
 		}
 	}
 
-	void server_session::remove_player_full_name_if_need() const {
+	void server_session::remove_player_full_name_if_need(const session_data& session_data) const {
 		if (const auto& player_name_container = server_data_.get_player_name_container(); player_name_container.
-			is_player_exist(session_data_->client_player_name())) {
-			server_data_.get_player_name_container().remove_player_name(session_data_->client_player_name());
-			log_with_endpoint(log_level::info, session_data_->remote_endpoint().to_boost_endpoint(),
-				"Player full name(name: ", session_data_->client_player_name().name, ", Tag: ",
-				session_data_->client_player_name().tag, ") is removed.");
+			is_player_exist(session_data.client_player_name())) {
+			server_data_.get_player_name_container().remove_player_name(session_data.client_player_name());
+			log_with_endpoint(log_level::info, session_data.remote_endpoint().to_boost_endpoint(),
+				"Player full name(name: ", session_data.client_player_name().name, ", Tag: ",
+				session_data.client_player_name().tag, ") is removed.");
 		}
 	}
 }

--- a/PlanetaMatchMakerServer/source/server/server_session.cpp
+++ b/PlanetaMatchMakerServer/source/server/server_session.cpp
@@ -35,6 +35,8 @@ namespace pgl {
 	}
 
 	void server_session::start_impl() {
+		if (is_stopping_.load(std::memory_order_acquire)) { return; }
+
 		// Reset session
 		session_data_ = std::make_unique<session_data>();
 
@@ -52,9 +54,12 @@ namespace pgl {
 	}
 
 	void server_session::handle_accepted_connection(const system::error_code& accept_error) {
+		if (is_stopping_.load(std::memory_order_acquire)) { return; }
+
 		spawn(strand_, [shared_this=shared_from_this(), accept_error](asio::yield_context yield) {
 			try {
 				try {
+					if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
 					if (accept_error) {
 						const auto extra_message = generate_string("Acception failed: ", accept_error.message());
 						throw server_session_error(extra_message);
@@ -120,6 +125,7 @@ namespace pgl {
 	}
 
 	void server_session::stop() {
+		is_stopping_.store(true, std::memory_order_release);
 		// dispatch runs inline when already on this strand, preserving restart ordering.
 		asio::dispatch(strand_, [shared_this = shared_from_this()] {
 			shared_this->stop_impl();
@@ -127,8 +133,10 @@ namespace pgl {
 	}
 
 	void server_session::stop_impl() {
-		finalize();
-		socket_.close();
+		if (session_data_) { finalize(); }
+
+		boost::system::error_code ignored_error;
+		socket_.close(ignored_error);
 	}
 
 	void server_session::finalize() const {
@@ -144,6 +152,7 @@ namespace pgl {
 	}
 
 	void server_session::restart() {
+		if (is_stopping_.load(std::memory_order_acquire)) { return; }
 		log(log_level::info, "Server session handler is restarted.");
 		asio::dispatch(strand_, [shared_this = shared_from_this()] {
 			shared_this->stop_impl();

--- a/PlanetaMatchMakerServer/source/server/server_session.hpp
+++ b/PlanetaMatchMakerServer/source/server/server_session.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 
 #include <boost/asio.hpp>
 
@@ -15,12 +16,13 @@ namespace pgl {
 	class server_session final : public std::enable_shared_from_this<server_session>, boost::noncopyable {
 	public:
 		server_session(boost::asio::ip::tcp::acceptor& acceptor,
-			server_data& server_data, const server_setting& server_setting,
+			std::mutex& acceptor_mutex, server_data& server_data, const server_setting& server_setting,
 			message_handler_invoker& message_handler_invoker);
 		void start();
 		void stop();
 	private:
 		boost::asio::ip::tcp::acceptor& acceptor_;
+		std::mutex& acceptor_mutex_;
 		server_data& server_data_;
 		const server_setting& server_setting_;
 		message_handler_invoker& message_handler_invoker_;
@@ -28,6 +30,7 @@ namespace pgl {
 		boost::asio::ip::tcp::socket socket_;
 		std::unique_ptr<session_data> session_data_;
 
+		void handle_accepted_connection(const boost::system::error_code& accept_error);
 		void finalize() const;
 		void restart();
 		void remove_hosting_room_if_need()const;

--- a/PlanetaMatchMakerServer/source/server/server_session.hpp
+++ b/PlanetaMatchMakerServer/source/server/server_session.hpp
@@ -18,7 +18,7 @@ namespace pgl {
 	public:
 		server_session(boost::asio::ip::tcp::acceptor& acceptor,
 			std::mutex& acceptor_mutex, server_data& server_data, const server_setting& server_setting,
-			message_handler_invoker& message_handler_invoker);
+			std::shared_ptr<const message_handler_invoker> message_handler_invoker);
 		void start();
 		void stop();
 	private:
@@ -26,7 +26,7 @@ namespace pgl {
 		std::mutex& acceptor_mutex_;
 		server_data& server_data_;
 		const server_setting& server_setting_;
-		message_handler_invoker& message_handler_invoker_;
+		std::shared_ptr<const message_handler_invoker> message_handler_invoker_;
 
 		// Socket operations and timeout timers share this strand through socket.get_executor().
 		boost::asio::strand<boost::asio::any_io_executor> strand_;
@@ -37,9 +37,9 @@ namespace pgl {
 		void start_impl();
 		void stop_impl();
 		void handle_accepted_connection(const boost::system::error_code& accept_error);
-		void finalize() const;
+		void finalize(const session_data& session_data) const;
 		void restart();
-		void remove_hosting_room_if_need()const;
-		void remove_player_full_name_if_need()const;
+		void remove_hosting_room_if_need(const session_data& session_data)const;
+		void remove_player_full_name_if_need(const session_data& session_data)const;
 	};
 }

--- a/PlanetaMatchMakerServer/source/server/server_session.hpp
+++ b/PlanetaMatchMakerServer/source/server/server_session.hpp
@@ -27,9 +27,13 @@ namespace pgl {
 		const server_setting& server_setting_;
 		message_handler_invoker& message_handler_invoker_;
 
+		// Socket operations and timeout timers share this strand through socket.get_executor().
+		boost::asio::strand<boost::asio::any_io_executor> strand_;
 		boost::asio::ip::tcp::socket socket_;
 		std::unique_ptr<session_data> session_data_;
 
+		void start_impl();
+		void stop_impl();
 		void handle_accepted_connection(const boost::system::error_code& accept_error);
 		void finalize() const;
 		void restart();

--- a/PlanetaMatchMakerServer/source/server/server_session.hpp
+++ b/PlanetaMatchMakerServer/source/server/server_session.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 
@@ -31,6 +32,7 @@ namespace pgl {
 		boost::asio::strand<boost::asio::any_io_executor> strand_;
 		boost::asio::ip::tcp::socket socket_;
 		std::unique_ptr<session_data> session_data_;
+		std::atomic_bool is_stopping_{false};
 
 		void start_impl();
 		void stop_impl();

--- a/PlanetaMatchMakerServer/source/server/server_thread.cpp
+++ b/PlanetaMatchMakerServer/source/server/server_thread.cpp
@@ -28,6 +28,11 @@ namespace pgl {
 
 	void server_thread::stop() {
 		for (auto&& session : server_sessions_) { session->stop(); }
+		{
+			std::lock_guard lock(acceptor_mutex_);
+			boost::system::error_code ignored_error;
+			acceptor_.cancel(ignored_error);
+		}
 		server_sessions_.clear();
 	}
 }

--- a/PlanetaMatchMakerServer/source/server/server_thread.cpp
+++ b/PlanetaMatchMakerServer/source/server/server_thread.cpp
@@ -12,13 +12,13 @@ namespace pgl {
 		acceptor_mutex_(acceptor_mutex),
 		server_data_(server_data),
 		server_setting_(server_setting),
-		message_handler_invoker_(message_handler_invoker_factory::make_unique_standard()) {}
+		message_handler_invoker_(message_handler_invoker_factory::make_shared_standard()) {}
 
 	void server_thread::start() {
 		server_sessions_.reserve(server_setting_.common.max_connection_per_thread);
 		for (auto i = 0u; i < server_setting_.common.max_connection_per_thread; ++i) {
 			auto conn_handler = std::make_shared<server_session>(acceptor_, acceptor_mutex_, server_data_,
-				server_setting_, *message_handler_invoker_);
+				server_setting_, message_handler_invoker_);
 			conn_handler->start();
 			server_sessions_.push_back(std::move(conn_handler));
 		}

--- a/PlanetaMatchMakerServer/source/server/server_thread.cpp
+++ b/PlanetaMatchMakerServer/source/server/server_thread.cpp
@@ -7,8 +7,9 @@
 
 namespace pgl {
 
-	server_thread::server_thread(boost::asio::ip::tcp::acceptor& acceptor, server_data& server_data,
-		const server_setting& server_setting): acceptor_(acceptor),
+	server_thread::server_thread(boost::asio::ip::tcp::acceptor& acceptor, std::mutex& acceptor_mutex,
+		server_data& server_data, const server_setting& server_setting): acceptor_(acceptor),
+		acceptor_mutex_(acceptor_mutex),
 		server_data_(server_data),
 		server_setting_(server_setting),
 		message_handler_invoker_(message_handler_invoker_factory::make_unique_standard()) {}
@@ -16,7 +17,7 @@ namespace pgl {
 	void server_thread::start() {
 		server_sessions_.reserve(server_setting_.common.max_connection_per_thread);
 		for (auto i = 0u; i < server_setting_.common.max_connection_per_thread; ++i) {
-			auto conn_handler = std::make_shared<server_session>(acceptor_, server_data_,
+			auto conn_handler = std::make_shared<server_session>(acceptor_, acceptor_mutex_, server_data_,
 				server_setting_, *message_handler_invoker_);
 			conn_handler->start();
 			server_sessions_.push_back(std::move(conn_handler));

--- a/PlanetaMatchMakerServer/source/server/server_thread.hpp
+++ b/PlanetaMatchMakerServer/source/server/server_thread.hpp
@@ -25,7 +25,7 @@ namespace pgl {
 		server_data& server_data_;
 		const server_setting& server_setting_;
 
-		std::unique_ptr<message_handler_invoker> message_handler_invoker_;
+		std::shared_ptr<const message_handler_invoker> message_handler_invoker_;
 		std::vector<std::shared_ptr<server_session>> server_sessions_;
 	};
 }

--- a/PlanetaMatchMakerServer/source/server/server_thread.hpp
+++ b/PlanetaMatchMakerServer/source/server/server_thread.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include <boost/asio.hpp>
@@ -15,11 +16,12 @@ namespace pgl {
 	class server_thread final : boost::noncopyable {
 	public:
 		server_thread(boost::asio::ip::tcp::acceptor& acceptor,
-			server_data& server_data, const server_setting& server_setting);
+			std::mutex& acceptor_mutex, server_data& server_data, const server_setting& server_setting);
 		void start();
 		void stop();
 	private:
 		boost::asio::ip::tcp::acceptor& acceptor_;
+		std::mutex& acceptor_mutex_;
 		server_data& server_data_;
 		const server_setting& server_setting_;
 

--- a/PlanetaMatchMakerServer/source/session/session_data.hpp
+++ b/PlanetaMatchMakerServer/source/session/session_data.hpp
@@ -5,7 +5,8 @@
 #include "client/player_full_name.hpp"
 
 namespace pgl {
-	// This class need not be thread safe because one session is processed in one thread.
+	// This class need not be thread safe because one session is processed serially through its session strand.
+	// Do not access it from outside the owning session strand.
 	// Each method may throw std::runtime_exception if errors occur.
 	class session_data final {
 	public:

--- a/PlanetaMatchMakerServerTest/PlanetaMatchMakerServerTest.vcxproj
+++ b/PlanetaMatchMakerServerTest/PlanetaMatchMakerServerTest.vcxproj
@@ -74,7 +74,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)obj\$(Platform)\$(Configuration)\PlanetaMatchMakerServer\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>datetime.obj;server_setting.obj;log.obj;network_layer.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>datetime.obj;server_setting.obj;log.obj;network_layer.obj;player_full_name.obj;room_data.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -100,13 +100,14 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)obj\$(Platform)\$(Configuration)\PlanetaMatchMakerServer\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>datetime.obj;server_setting.obj;log.obj;network_layer.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>datetime.obj;server_setting.obj;log.obj;network_layer.obj;player_full_name.obj;room_data.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="checked_static_cast_test.cpp" />
     <ClCompile Include="datetime_test.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="room_data_container_test.cpp" />
     <ClCompile Include="serialize_pack_test.cpp" />
     <ClCompile Include="server_setting_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/PlanetaMatchMakerServerTest/PlanetaMatchMakerServerTest.vcxproj.filters
+++ b/PlanetaMatchMakerServerTest/PlanetaMatchMakerServerTest.vcxproj.filters
@@ -4,6 +4,7 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="checked_static_cast_test.cpp" />
     <ClCompile Include="datetime_test.cpp" />
+    <ClCompile Include="room_data_container_test.cpp" />
     <ClCompile Include="serialize_pack_test.cpp" />
     <ClCompile Include="server_setting_test.cpp" />
     <ClCompile Include="thread_safe_data_container_test.cpp" />

--- a/PlanetaMatchMakerServerTest/room_data_container_test.cpp
+++ b/PlanetaMatchMakerServerTest/room_data_container_test.cpp
@@ -88,6 +88,25 @@ BOOST_AUTO_TEST_SUITE(room_data_container_test)
 		BOOST_CHECK(next_join_result.result == room_data_container::join_room_result::room_full);
 	}
 
+	BOOST_AUTO_TEST_CASE(test_try_release_player_join_reservation_restores_reserved_slot) {
+		// set up
+		auto container = room_data_container();
+		container.add_or_update(make_room(1, 1, 2, 1));
+		const auto reserve_result = container.try_reserve_player_for_join(1,
+			game_host_connection_establish_mode::builtin, {});
+		BOOST_REQUIRE(reserve_result.result == room_data_container::join_room_result::accepted);
+
+		// exercise
+		const auto release_result = container.try_release_player_join_reservation(1);
+		const auto next_join_result = container.try_reserve_player_for_join(1,
+			game_host_connection_establish_mode::builtin, {});
+
+		// verify
+		BOOST_CHECK(release_result);
+		BOOST_CHECK_EQUAL(container.get(1).current_player_count, 2);
+		BOOST_CHECK(next_join_result.result == room_data_container::join_room_result::accepted);
+	}
+
 	BOOST_AUTO_TEST_CASE(test_host_report_confirms_in_flight_join_reservation) {
 		// set up
 		auto container = room_data_container();

--- a/PlanetaMatchMakerServerTest/room_data_container_test.cpp
+++ b/PlanetaMatchMakerServerTest/room_data_container_test.cpp
@@ -67,6 +67,49 @@ BOOST_AUTO_TEST_SUITE(room_data_container_test)
 		BOOST_CHECK_EQUAL(container.get(1).current_player_count, 2);
 	}
 
+	BOOST_AUTO_TEST_CASE(test_host_report_does_not_drop_in_flight_join_reservation) {
+		// set up
+		auto container = room_data_container();
+		container.add_or_update(make_room(1, 1, 2, 1));
+		const auto reserve_result = container.try_reserve_player_for_join(1,
+			game_host_connection_establish_mode::builtin, {});
+		BOOST_REQUIRE(reserve_result.result == room_data_container::join_room_result::accepted);
+
+		// exercise
+		const auto update_result = container.try_update_with_host_reported_current_player_count(1, true, 1,
+			[](auto&) {});
+		const auto next_join_result = container.try_reserve_player_for_join(1,
+			game_host_connection_establish_mode::builtin, {});
+
+		// verify
+		BOOST_REQUIRE(update_result.has_value());
+		BOOST_CHECK_EQUAL(update_result->current_player_count, 2);
+		BOOST_CHECK_EQUAL(container.get(1).current_player_count, 2);
+		BOOST_CHECK(next_join_result.result == room_data_container::join_room_result::room_full);
+	}
+
+	BOOST_AUTO_TEST_CASE(test_host_report_confirms_in_flight_join_reservation) {
+		// set up
+		auto container = room_data_container();
+		container.add_or_update(make_room(1, 1, 4, 1));
+		const auto reserve_result = container.try_reserve_player_for_join(1,
+			game_host_connection_establish_mode::builtin, {});
+		BOOST_REQUIRE(reserve_result.result == room_data_container::join_room_result::accepted);
+
+		// exercise
+		const auto confirmed_result = container.try_update_with_host_reported_current_player_count(1, true, 2,
+			[](auto&) {});
+		const auto reduced_result = container.try_update_with_host_reported_current_player_count(1, true, 1,
+			[](auto&) {});
+
+		// verify
+		BOOST_REQUIRE(confirmed_result.has_value());
+		BOOST_CHECK_EQUAL(confirmed_result->current_player_count, 2);
+		BOOST_REQUIRE(reduced_result.has_value());
+		BOOST_CHECK_EQUAL(reduced_result->current_player_count, 1);
+		BOOST_CHECK_EQUAL(container.get(1).current_player_count, 1);
+	}
+
 	BOOST_AUTO_TEST_CASE(test_concurrent_try_reserve_player_for_join_does_not_exceed_max_player_count) {
 		// set up
 		auto container = room_data_container();

--- a/PlanetaMatchMakerServerTest/room_data_container_test.cpp
+++ b/PlanetaMatchMakerServerTest/room_data_container_test.cpp
@@ -1,0 +1,119 @@
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+#include "../PlanetaMatchMakerServer/source/room/room_data_container.hpp"
+
+using namespace pgl;
+
+namespace {
+	constexpr auto public_open_room = room_setting_flag::public_room | room_setting_flag::open_room;
+
+	endpoint make_endpoint(const port_number_type port_number) {
+		auto endpoint = pgl::endpoint();
+		endpoint.port_number = port_number;
+		return endpoint;
+	}
+
+	room_data make_room(const room_id_t room_id, const player_tag_t host_tag, const uint8_t max_player_count,
+		const uint8_t current_player_count, const room_setting_flag setting_flags = public_open_room) {
+		return {
+			room_id,
+			{ u8"host", host_tag },
+			setting_flags,
+			{},
+			max_player_count,
+			datetime(2024, 1, 1),
+			make_endpoint(1234),
+			game_host_connection_establish_mode::builtin,
+			make_endpoint(5678),
+			{},
+			current_player_count
+		};
+	}
+}
+
+BOOST_AUTO_TEST_SUITE(room_data_container_test)
+
+	BOOST_AUTO_TEST_CASE(test_try_reserve_player_for_join_accepts_and_increments_current_player_count) {
+		// set up
+		auto container = room_data_container();
+		container.add_or_update(make_room(1, 1, 2, 1));
+
+		// exercise
+		const auto result = container.try_reserve_player_for_join(1, game_host_connection_establish_mode::builtin, {});
+
+		// verify
+		BOOST_CHECK(result.result == room_data_container::join_room_result::accepted);
+		BOOST_REQUIRE(result.room.has_value());
+		BOOST_CHECK_EQUAL(result.room->current_player_count, 2);
+		BOOST_CHECK_EQUAL(container.get(1).current_player_count, 2);
+	}
+
+	BOOST_AUTO_TEST_CASE(test_try_reserve_player_for_join_rejects_full_room_without_incrementing) {
+		// set up
+		auto container = room_data_container();
+		container.add_or_update(make_room(1, 1, 2, 2));
+
+		// exercise
+		const auto result = container.try_reserve_player_for_join(1, game_host_connection_establish_mode::builtin, {});
+
+		// verify
+		BOOST_CHECK(result.result == room_data_container::join_room_result::room_full);
+		BOOST_REQUIRE(result.room.has_value());
+		BOOST_CHECK_EQUAL(result.room->current_player_count, 2);
+		BOOST_CHECK_EQUAL(container.get(1).current_player_count, 2);
+	}
+
+	BOOST_AUTO_TEST_CASE(test_concurrent_try_reserve_player_for_join_does_not_exceed_max_player_count) {
+		// set up
+		auto container = room_data_container();
+		constexpr auto max_player_count = uint8_t{4};
+		container.add_or_update(make_room(1, 1, max_player_count, 1));
+		constexpr auto thread_count = 8u;
+		std::atomic<bool> can_start = false;
+		std::atomic<unsigned> accepted_count = 0;
+		std::atomic<unsigned> full_count = 0;
+		std::vector<std::thread> threads;
+		threads.reserve(thread_count);
+
+		// exercise
+		for (auto thread_index = 0u; thread_index < thread_count; ++thread_index) {
+			threads.emplace_back([&] {
+				while (!can_start.load(std::memory_order_acquire)) { std::this_thread::yield(); }
+
+				const auto result = container.try_reserve_player_for_join(1,
+					game_host_connection_establish_mode::builtin, {});
+				if (result.result == room_data_container::join_room_result::accepted) { ++accepted_count; }
+				if (result.result == room_data_container::join_room_result::room_full) { ++full_count; }
+			});
+		}
+
+		can_start.store(true, std::memory_order_release);
+		for (auto& thread : threads) { thread.join(); }
+
+		// verify
+		BOOST_CHECK_EQUAL(accepted_count.load(), max_player_count - 1);
+		BOOST_CHECK_EQUAL(full_count.load(), thread_count - accepted_count.load());
+		BOOST_CHECK_EQUAL(container.get(1).current_player_count, max_player_count);
+	}
+
+	BOOST_AUTO_TEST_CASE(test_search_with_total_returns_match_count_and_total_count_from_one_snapshot) {
+		// set up
+		auto container = room_data_container();
+		container.add_or_update(make_room(1, 1, 4, 1));
+		container.add_or_update(make_room(2, 2, 4, 1, room_setting_flag::public_room));
+
+		// exercise
+		const auto result = container.search_with_total(room_data_sort_kind::name_ascending,
+			room_search_target_flag::public_room | room_search_target_flag::open_room, {});
+
+		// verify
+		BOOST_CHECK_EQUAL(result.total_room_count, 2);
+		BOOST_REQUIRE_EQUAL(result.data.size(), 1);
+		BOOST_CHECK_EQUAL(result.data.front().room_id, 1);
+	}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/PlanetaMatchMakerServerTest/thread_safe_data_container_test.cpp
+++ b/PlanetaMatchMakerServerTest/thread_safe_data_container_test.cpp
@@ -1,4 +1,7 @@
 #include <array>
+#include <atomic>
+#include <thread>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 #include <boost/test/data/test_case.hpp>
@@ -62,6 +65,24 @@ const auto data4 = test_struct1{
 	100, 1.2f, true, {6, 7, 8}, u8"test4", 4
 };
 
+struct concurrent_test_struct final {
+	uint32_t id;
+	uint32_t unique;
+	uint32_t value;
+
+	bool operator==(const concurrent_test_struct& other) const {
+		return id == other.id && unique == other.unique && value == other.value;
+	}
+};
+
+std::ostream& operator<<(std::ostream& os, const concurrent_test_struct& d) {
+	os << nameof::nameof_type<concurrent_test_struct>() << "{" << d.id << "," << d.unique << "," << d.value << "}";
+	return os;
+}
+
+using concurrent_container_t = thread_safe_data_container<concurrent_test_struct, &concurrent_test_struct::id, &
+	concurrent_test_struct::unique>;
+
 BOOST_AUTO_TEST_SUITE(thread_safe_data_container_test)
 	////////////////////////////////
 	// add_or_update, get 
@@ -111,6 +132,25 @@ BOOST_AUTO_TEST_SUITE(thread_safe_data_container_test)
 		BOOST_CHECK_EQUAL(actual2, updated_data2);
 	}
 
+	BOOST_AUTO_TEST_CASE(test_update_releases_previous_unique_variable) {
+		// set up
+		auto container = container_t();
+		auto updated_data1 = data3;
+		updated_data1.id = data1.id;
+		auto data_using_old_unique1 = test_struct1{19, -13.2f, false, {64, 47, 84}, data1.unique1, 10};
+		container.add_or_update(data1);
+		container.add_or_update(data2);
+		container.add_or_update(updated_data1);
+
+		// exercise
+		const auto result = container.add_or_update(data_using_old_unique1);
+		const auto actual = container.get(data_using_old_unique1.id);
+
+		// verify
+		BOOST_CHECK_EQUAL(result, true);
+		BOOST_CHECK_EQUAL(actual, data_using_old_unique1);
+	}
+
 	BOOST_DATA_TEST_CASE(test_add_already_exist_unique_variable, unit_test::data::make({
 		// id is different but unique variable1 is duplicated
 		test_struct1{19, -13.2f, false, {64, 47, 84}, u8"test1", 0},
@@ -137,6 +177,46 @@ BOOST_AUTO_TEST_SUITE(thread_safe_data_container_test)
 
 		// verify
 		BOOST_CHECK_EQUAL(actual1, data1);
+	}
+
+	BOOST_AUTO_TEST_CASE(test_concurrent_add_or_update_and_search) {
+		// set up
+		auto container = concurrent_container_t();
+		constexpr auto thread_count = 8u;
+		constexpr auto data_count_per_thread = 500u;
+		std::atomic<bool> can_start = false;
+		std::atomic<unsigned> exception_count = 0;
+		std::vector<std::thread> threads;
+		threads.reserve(thread_count);
+
+		// exercise
+		for (auto thread_index = 0u; thread_index < thread_count; ++thread_index) {
+			threads.emplace_back([&, thread_index] {
+				while (!can_start.load(std::memory_order_acquire)) { std::this_thread::yield(); }
+
+				try {
+					for (auto data_index = 0u; data_index < data_count_per_thread; ++data_index) {
+						const auto id = thread_index * data_count_per_thread + data_index + 1u;
+						container.add_or_update(concurrent_test_struct{id, id, id * 2u});
+
+						if (data_index % 16u == 0u) {
+							[[maybe_unused]] const auto _ = container.search(
+								[](const auto& l, const auto& r) { return l.id < r.id; },
+								[](const auto&) { return true; }
+							);
+						}
+					}
+				}
+				catch (...) { ++exception_count; }
+			});
+		}
+
+		can_start.store(true, std::memory_order_release);
+		for (auto& thread : threads) { thread.join(); }
+
+		// verify
+		BOOST_CHECK_EQUAL(exception_count.load(), 0u);
+		BOOST_CHECK_EQUAL(container.size(), thread_count * data_count_per_thread);
 	}
 
 	////////////////////////////////

--- a/PlanetaMatchMakerServerTest/thread_safe_data_container_test.cpp
+++ b/PlanetaMatchMakerServerTest/thread_safe_data_container_test.cpp
@@ -179,6 +179,41 @@ BOOST_AUTO_TEST_SUITE(thread_safe_data_container_test)
 		BOOST_CHECK_EQUAL(actual1, data1);
 	}
 
+	BOOST_AUTO_TEST_CASE(test_try_update_for_exist_data) {
+		// set up
+		auto container = container_t();
+		container.add_or_update(data1);
+
+		// exercise
+		const auto result = container.try_update(data1.id, [](auto& data) {
+			data.value1 = data3.value1;
+			data.unique1 = data3.unique1;
+			data.unique2 = data3.unique2;
+		});
+		auto expected = data1;
+		expected.value1 = data3.value1;
+		expected.unique1 = data3.unique1;
+		expected.unique2 = data3.unique2;
+
+		// verify
+		BOOST_REQUIRE(result.has_value());
+		BOOST_CHECK_EQUAL(*result, expected);
+		BOOST_CHECK_EQUAL(container.get(data1.id), expected);
+	}
+
+	BOOST_AUTO_TEST_CASE(test_try_update_for_not_exist_data) {
+		// set up
+		auto container = container_t();
+		container.add_or_update(data1);
+
+		// exercise
+		const auto result = container.try_update(data2.id, [](auto& data) { data.value1 = 9.8f; });
+
+		// verify
+		BOOST_CHECK(!result.has_value());
+		BOOST_CHECK(!container.contains(data2.id));
+	}
+
 	BOOST_AUTO_TEST_CASE(test_concurrent_add_or_update_and_search) {
 		// set up
 		auto container = concurrent_container_t();
@@ -261,6 +296,77 @@ BOOST_AUTO_TEST_SUITE(thread_safe_data_container_test)
 			unique_variable_duplication_error);
 	}
 
+	BOOST_AUTO_TEST_CASE(test_try_assign_id_and_add_under_limit) {
+		// set up
+		auto container = container_t();
+		auto non_const_data1 = data1;
+
+		// exercise
+		const auto result = container.try_assign_id_and_add(non_const_data1, 1,
+			[] { return static_cast<uint8_t>(1); });
+
+		// verify
+		BOOST_REQUIRE(result.has_value());
+		BOOST_CHECK_EQUAL(*result, 1);
+		non_const_data1.id = *result;
+		BOOST_CHECK_EQUAL(container.get(*result), non_const_data1);
+	}
+
+	BOOST_AUTO_TEST_CASE(test_try_assign_id_and_add_reached_limit) {
+		// set up
+		auto container = container_t();
+		auto non_const_data1 = data1;
+		auto non_const_data2 = data2;
+		container.try_assign_id_and_add(non_const_data1, 1, [] { return static_cast<uint8_t>(1); });
+
+		// exercise
+		const auto result = container.try_assign_id_and_add(non_const_data2, 1,
+			[] { return static_cast<uint8_t>(2); });
+
+		// verify
+		BOOST_CHECK(!result.has_value());
+		BOOST_CHECK_EQUAL(container.size(), 1);
+	}
+
+	BOOST_AUTO_TEST_CASE(test_concurrent_try_assign_id_and_add_does_not_exceed_limit) {
+		// set up
+		auto container = concurrent_container_t();
+		constexpr auto thread_count = 8u;
+		constexpr auto data_count_per_thread = 100u;
+		constexpr auto max_count = 250u;
+		std::atomic<bool> can_start = false;
+		std::atomic<unsigned> success_count = 0;
+		std::atomic<unsigned> exception_count = 0;
+		std::atomic<uint32_t> next_value = 1;
+		std::vector<std::thread> threads;
+		threads.reserve(thread_count);
+
+		// exercise
+		for (auto thread_index = 0u; thread_index < thread_count; ++thread_index) {
+			threads.emplace_back([&] {
+				while (!can_start.load(std::memory_order_acquire)) { std::this_thread::yield(); }
+
+				try {
+					for (auto data_index = 0u; data_index < data_count_per_thread; ++data_index) {
+						const auto value = next_value.fetch_add(1, std::memory_order_relaxed);
+						auto data = concurrent_test_struct{0, value, value * 2u};
+						const auto result = container.try_assign_id_and_add(data, max_count, [value] { return value; });
+						if (result.has_value()) { success_count.fetch_add(1, std::memory_order_relaxed); }
+					}
+				}
+				catch (...) { exception_count.fetch_add(1, std::memory_order_relaxed); }
+			});
+		}
+
+		can_start.store(true, std::memory_order_release);
+		for (auto& thread : threads) { thread.join(); }
+
+		// verify
+		BOOST_CHECK_EQUAL(exception_count.load(), 0u);
+		BOOST_CHECK_EQUAL(success_count.load(), max_count);
+		BOOST_CHECK_EQUAL(container.size(), max_count);
+	}
+
 	////////////////////////////////
 	// get 
 	////////////////////////////////
@@ -273,6 +379,35 @@ BOOST_AUTO_TEST_SUITE(thread_safe_data_container_test)
 		// exercise and verify
 		// ReSharper disable once CppNoDiscardExpression
 		BOOST_CHECK_THROW(container.get(9), std::out_of_range); // NOLINT(clang-diagnostic-unused-result)
+	}
+
+	////////////////////////////////
+	// try_get
+	////////////////////////////////
+
+	BOOST_AUTO_TEST_CASE(test_try_get_for_exist_data) {
+		// set up
+		auto container = container_t();
+		container.add_or_update(data1);
+
+		// exercise
+		const auto result = container.try_get(data1.id);
+
+		// verify
+		BOOST_REQUIRE(result.has_value());
+		BOOST_CHECK_EQUAL(*result, data1);
+	}
+
+	BOOST_AUTO_TEST_CASE(test_try_get_for_not_exist_data) {
+		// set up
+		auto container = container_t();
+		container.add_or_update(data1);
+
+		// exercise
+		const auto result = container.try_get(data2.id);
+
+		// verify
+		BOOST_CHECK(!result.has_value());
 	}
 
 	////////////////////////////////
@@ -401,6 +536,46 @@ BOOST_AUTO_TEST_SUITE(thread_safe_data_container_test)
 
 		// verify
 		BOOST_CHECK_EQUAL(result, false);
+	}
+
+	BOOST_AUTO_TEST_CASE(test_try_remove_if_for_exist_data) {
+		// set up
+		auto container = container_t();
+		container.add_or_update(data1);
+
+		// exercise
+		const auto result = container.try_remove_if(data1.id, [](const auto&) { return true; });
+
+		// verify
+		BOOST_REQUIRE(result.has_value());
+		BOOST_CHECK_EQUAL(*result, data1);
+		BOOST_CHECK(!container.contains(data1.id));
+	}
+
+	BOOST_AUTO_TEST_CASE(test_try_remove_if_for_not_exist_data) {
+		// set up
+		auto container = container_t();
+		container.add_or_update(data1);
+
+		// exercise
+		const auto result = container.try_remove_if(data2.id, [](const auto&) { return true; });
+
+		// verify
+		BOOST_CHECK(!result.has_value());
+		BOOST_CHECK(container.contains(data1.id));
+	}
+
+	BOOST_AUTO_TEST_CASE(test_try_remove_if_when_rejected) {
+		// set up
+		auto container = container_t();
+		container.add_or_update(data1);
+
+		// exercise
+		const auto result = container.try_remove_if(data1.id, [](const auto&) { return false; });
+
+		// verify
+		BOOST_CHECK(!result.has_value());
+		BOOST_CHECK(container.contains(data1.id));
 	}
 
 	////////////////////////////////


### PR DESCRIPTION
Closes #14

## Summary
- harden server session, room, and shared data access against thread-safety races
- serialize socket writes and guard exception paths during request handling
- add and update C++ unit coverage for room data and thread-safe data containers

## Validation
- Not run in this session