### PR TITLE
[update] #15 add thread ID and session number to server log

### DIFF
--- a/Documents/ServerSettings.md
+++ b/Documents/ServerSettings.md
@@ -53,6 +53,8 @@ Detail of each `game_version_check_mode` options is below.
 |file_log_level|string ("debug", "info", "warning", "error", "fatal")|"info"|PMMS_LOG_FILE_LOG_LEVEL|A threshold of file log by level.|
 |file_log_path|string (path)|""|PMMS_LOG_FILE_LOG_PATH|A path of file to ouput log. `/var/log/pmms.log` (Linux) or `C:\log\pmms.log` (Windows) are used if this setting is empty.|
 
+Log lines include the current thread ID as `[thread:<id>]`. Logs emitted while processing an accepted connection also include `[session:<number>]` before the client endpoint. Session numbers are process-local connection numbers that start from `1`.
+
 ### `connection_test` Section
 
 |Name|Type|Default|Env Var|Explanation|

--- a/PlanetaMatchMakerServer/PlanetaMatchMakerServer.vcxproj
+++ b/PlanetaMatchMakerServer/PlanetaMatchMakerServer.vcxproj
@@ -150,6 +150,7 @@
     <ClInclude Include="source\server\server_setting.hpp" />
     <ClInclude Include="source\server\server_shared_data_repository.hpp" />
     <ClInclude Include="source\server\server_thread.hpp" />
+    <ClInclude Include="source\session\session_constants.hpp" />
     <ClInclude Include="source\session\session_data.hpp" />
     <ClInclude Include="source\utilities\application.hpp" />
     <ClInclude Include="source\utilities\asio_stream_compatibility.hpp" />

--- a/PlanetaMatchMakerServer/source/logger/boost_logger_common.cpp
+++ b/PlanetaMatchMakerServer/source/logger/boost_logger_common.cpp
@@ -11,7 +11,7 @@ namespace pgl {
 	}
 
 	log::formatter get_boost_logger_default_formatter() {
-		return log::expressions::format("[%1%] [%2%] %3%%4%: %5%")
+		return log::expressions::format("[%1%] [thread:%2%] %3%%4%: %5%")
 			% log::expressions::format_date_time<posix_time::ptime>(
 				"TimeStamp", "%Y-%m-%d %H:%M:%S.%f")
 			% log::expressions::attr<log::attributes::current_thread_id::value_type>("ThreadID")

--- a/PlanetaMatchMakerServer/source/logger/log.hpp
+++ b/PlanetaMatchMakerServer/source/logger/log.hpp
@@ -3,6 +3,7 @@
 #include "minimal_serializer/string_utility.hpp"
 
 #include "logger.hpp"
+#include "session/session_constants.hpp"
 #include "utilities/asio_stream_compatibility.hpp"
 
 namespace pgl {
@@ -28,6 +29,15 @@ namespace pgl {
 		const boost::asio::basic_socket<boost::asio::ip::tcp>::endpoint_type& endpoint,
 		Params&& ... params) {
 		log_impl(level, minimal_serializer::generate_string(" @", endpoint),
+			minimal_serializer::generate_string(params...));
+	}
+
+	// Log thread safely with information of session number and endpoint.
+	template <typename ... Params>
+	void log_with_session_and_endpoint(const log_level level, const session_number_t session_number,
+		const boost::asio::basic_socket<boost::asio::ip::tcp>::endpoint_type& endpoint,
+		Params&& ... params) {
+		log_impl(level, minimal_serializer::generate_string(" [session:", session_number, "] @", endpoint),
 			minimal_serializer::generate_string(params...));
 	}
 }

--- a/PlanetaMatchMakerServer/source/logger/logger_common.cpp
+++ b/PlanetaMatchMakerServer/source/logger/logger_common.cpp
@@ -1,4 +1,5 @@
 #include <ostream>
+#include <thread>
 
 #include "minimal_serializer/string_utility.hpp"
 
@@ -11,7 +12,7 @@ using namespace minimal_serializer;
 namespace pgl {
 	void output_formatted_log(ostream& out_stream, log_level level, const string& header,
 		const std::string& message) {
-		out_stream << "[" << get_now_datetime_string() << "] " << generate_string(level) << header
-			<< ": " << message << std::endl;
+		out_stream << "[" << get_now_datetime_string() << "] [thread:" << std::this_thread::get_id()
+			<< "] " << generate_string(level) << header << ": " << message << std::endl;
 	}
 }

--- a/PlanetaMatchMakerServer/source/message/message_handle_utilities.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handle_utilities.cpp
@@ -5,12 +5,12 @@ namespace pgl {
 		const room_data_container& room_data_container, room_id_t room_id) {
 		// Check room existence
 		if (room_data_container.try_get(room_id).has_value()) {
-			log_with_endpoint(log_level::debug, param->socket.remote_endpoint(), "The room whose id is \"", room_id,
+			log_with_session(log_level::debug, param, "The room whose id is \"", room_id,
 				"\" exists.");
 			return true;
 		}
 
-		log_with_endpoint(log_level::error, param->socket.remote_endpoint(), "The room whose id is \"", room_id,
+		log_with_session(log_level::error, param, "The room whose id is \"", room_id,
 			"\" doesn't exist.");
 		return false;
 	}

--- a/PlanetaMatchMakerServer/source/message/message_handle_utilities.hpp
+++ b/PlanetaMatchMakerServer/source/message/message_handle_utilities.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <memory>
+#include <utility>
+
 #include "async/timer.hpp"
 #include "async/read_write.hpp"
 #include "server/server_errors.hpp"
@@ -7,8 +10,26 @@
 #include "logger/log.hpp"
 #include "messages.hpp"
 #include "message_handle_parameter.hpp"
+#include "session/session_data.hpp"
 
 namespace pgl {
+	template <typename ... Params>
+	void log_with_session(const log_level level, const message_handle_parameter& param, Params&& ... params) {
+		if (const auto session_number = param.session_data.session_number(); session_number.has_value()) {
+			log_with_session_and_endpoint(level, *session_number, param.socket.remote_endpoint(),
+				std::forward<Params>(params)...);
+		}
+		else {
+			log_with_endpoint(level, param.socket.remote_endpoint(), std::forward<Params>(params)...);
+		}
+	}
+
+	template <typename ... Params>
+	void log_with_session(const log_level level, const std::shared_ptr<message_handle_parameter>& param,
+		Params&& ... params) {
+		log_with_session(level, *param, std::forward<Params>(params)...);
+	}
+
 	// Send data to remote endpoint. server_session_error will be thrown when send error occurred.
 	template <serializable FirstData, serializable... RestData>
 	void send(std::shared_ptr<message_handle_parameter> param, FirstData&& first_data, RestData&&... rest_data) {
@@ -21,7 +42,7 @@ namespace pgl {
 					packed_async_write(
 						param->socket, param->yield, first_data, rest_data...);
 				});
-			log_with_endpoint(log_level::debug, param->socket.remote_endpoint(), "Send ", data_summary,
+			log_with_session(log_level::debug, param, "Send ", data_summary,
 				" to the client.");
 		}
 		catch (const boost::system::system_error& e) {
@@ -51,7 +72,7 @@ namespace pgl {
 				[param, &first_data, &rest_data...]()mutable {
 					unpacked_async_read(param->socket, param->yield, first_data, rest_data...);
 				});
-			log_with_endpoint(log_level::debug, param->socket.remote_endpoint(), "Receive ", data_summary,
+			log_with_session(log_level::debug, param, "Receive ", data_summary,
 				" from the client.");
 		}
 		catch (const boost::system::system_error& e) {

--- a/PlanetaMatchMakerServer/source/message/message_handler.hpp
+++ b/PlanetaMatchMakerServer/source/message/message_handler.hpp
@@ -52,7 +52,7 @@ namespace pgl {
 
 		void operator()(const request_message_header& header, std::shared_ptr<message_handle_parameter> param) final {
 			// receive message
-			log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Receive ", header.message_type,
+			log_with_session(log_level::info, param, "Receive ", header.message_type,
 				" message.");
 			RequestMessage message{};
 			receive(param, message);
@@ -67,7 +67,7 @@ namespace pgl {
 			std::function<void()> on_reply_failure;
 			try {
 				// handle message
-				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Handle ",
+				log_with_session(log_level::info, param, "Handle ",
 					header.message_type, " message.");
 				auto result = handle_message(message, param);
 				is_disconnect_required = result.is_disconnect_required;
@@ -77,7 +77,7 @@ namespace pgl {
 				disconnect_reason = "Disconnect due to message handling result.";
 			}
 			catch (const client_error& e) {
-				log_with_endpoint(log_level::info, param->socket.remote_endpoint(),
+				log_with_session(log_level::info, param,
 					"Client error occurred while handling ", header.message_type,
 					" message: ", e.message());
 				is_disconnect_required = e.is_disconnect_required();
@@ -87,7 +87,7 @@ namespace pgl {
 				disconnect_reason = "Disconnect due to not continuable client error.";
 			}
 			catch (const server_error& e) {
-				log_with_endpoint(log_level::info, param->socket.remote_endpoint(),
+				log_with_session(log_level::info, param,
 					"Server error occurred while handling ", header.message_type,
 					" message: ", e.message());
 				is_disconnect_required = e.is_disconnect_required();
@@ -101,14 +101,14 @@ namespace pgl {
 			if constexpr (!std::is_same_v<ReplyMessage, no_reply>) {
 				try {
 					if (reply_bodies.empty()) {
-						log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Reply ",
+						log_with_session(log_level::info, param, "Reply ",
 							header.message_type, " message without body (", get_packed_size<reply_message_header>(),
 							" bytes).");
 						send(param, reply_header);
 					}
 					else {
 						for (auto&& reply_body : reply_bodies) {
-							log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Reply ",
+							log_with_session(log_level::info, param, "Reply ",
 								header.message_type, " message (", get_packed_size<reply_message_header, ReplyMessage>(),
 								" bytes).");
 							send(param, reply_header, reply_body);
@@ -119,9 +119,9 @@ namespace pgl {
 					if (on_reply_failure) {
 						try { on_reply_failure(); }
 						catch (const std::exception& e) {
-							log(log_level::error, "Failed to run reply failure cleanup: ", e.what());
+							log_with_session(log_level::error, param, "Failed to run reply failure cleanup: ", e.what());
 						}
-						catch (...) { log(log_level::error, "Failed to run reply failure cleanup."); }
+						catch (...) { log_with_session(log_level::error, param, "Failed to run reply failure cleanup."); }
 					}
 					throw;
 				}

--- a/PlanetaMatchMakerServer/source/message/message_handler_invoker.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handler_invoker.cpp
@@ -41,13 +41,13 @@ namespace pgl {
 		const auto message_handler = make_message_handler(header.message_type);
 		constexpr auto header_size = minimal_serializer::serialized_size_v<request_message_header>;
 		const auto message_size = message_handler->get_message_size();
-		log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Message header received. (type: ",
+		log_with_session(log_level::info, param, "Message header received. (type: ",
 			header.message_type, ", size: ", header_size, ")");
 
 		// Receive and process a body of message
 		(*message_handler)(header, param);
 
-		log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Message processed. (type: ",
+		log_with_session(log_level::info, param, "Message processed. (type: ",
 			header.message_type, ", size: ", message_size, ")");
 	}
 }

--- a/PlanetaMatchMakerServer/source/message/message_handlers/authentication_request_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/authentication_request_message_handler.cpp
@@ -32,7 +32,7 @@ namespace pgl {
 
 		// Check if the client api version matches the server api version. If not, reply authentication failure and disconnect the client
 		if (message.api_version != api_version) {
-			log_with_endpoint(log_level::info, param->socket.remote_endpoint(),
+			log_with_session(log_level::info, param,
 				"Authentication failed. The client api version doesn't match to the server api version. (server api version: ",
 				api_version, ", client api version: ", message.api_version, ")");
 			return {
@@ -48,7 +48,7 @@ namespace pgl {
 		// Check if the client game id matches the server game id. If not, reply authentication failure and disconnect the client
 		if (const auto server_game_id = game_id_t(param->server_setting.authentication.game_id); message.game_id !=
 			server_game_id) {
-			log_with_endpoint(log_level::info, param->socket.remote_endpoint(),
+			log_with_session(log_level::info, param,
 				"Authentication failed. The client game id doesn't match to the server id version. (server game version: ",
 				server_game_id, ", client game version: ", message.game_id, ")");
 			return {
@@ -64,7 +64,7 @@ namespace pgl {
 		// Check if the client game version matches the server game version if game version check is enabled. If not, reply authentication failure and disconnect the client
 		if (param->server_setting.authentication.enable_game_version_check && message.game_version !=
 			server_game_version) {
-			log_with_endpoint(log_level::info, param->socket.remote_endpoint(),
+			log_with_session(log_level::info, param,
 				"Authentication failed. The client game version doesn't match to the server game version. (server game version: ",
 				server_game_version, ", client game version: ", message.game_version, ")");
 			return {
@@ -77,12 +77,12 @@ namespace pgl {
 			};
 		}
 
-		log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Authentication succeeded.");
+		log_with_session(log_level::info, param, "Authentication succeeded.");
 
 		// Generate player full name
 		const auto player_full_name = param->server_data.get_player_name_container().assign_player_name(
 			message.player_name);
-		log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "A player \"", player_full_name.name,
+		log_with_session(log_level::info, param, "A player \"", player_full_name.name,
 			"\" is registered with tag \"", player_full_name.tag, "\"");
 		param->session_data.set_client_player_name(player_full_name);
 

--- a/PlanetaMatchMakerServer/source/message/message_handlers/connection_test_request_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/connection_test_request_message_handler.cpp
@@ -39,13 +39,13 @@ namespace pgl {
 
 		// Check the reply matches test text
 		if (result_text != test_text) {
-			log_with_endpoint(log_level::info, param.socket.remote_endpoint(), "Connect to ", target_endpoint,
+			log_with_session(log_level::info, param, "Connect to ", target_endpoint,
 				" successfully, but target endpoint replied reply wrong message:\n expected message is \"", test_text,
 				"\", but received \"", result_text, "\".");
 			return false;
 		}
 
-		log_with_endpoint(log_level::info, param.socket.remote_endpoint(), "Connect to ",
+		log_with_session(log_level::info, param, "Connect to ",
 			target_endpoint, " successfully");
 		return true;
 	}
@@ -94,7 +94,7 @@ namespace pgl {
 
 				// Check the reply matches test text
 				if (result_text != test_text) {
-					log_with_endpoint(log_level::info, param.socket.remote_endpoint(), "Connect to ", target_endpoint,
+					log_with_session(log_level::info, param, "Connect to ", target_endpoint,
 						" successfully, but target endpoint replied reply wrong message:\n expected message is \"",
 						test_text, "\", but received \"", result_text, "\". (", i + 1, "/", try_count, " attempts)");
 					is_succeeded = false;
@@ -107,18 +107,18 @@ namespace pgl {
 			catch (const system::system_error& e) {
 				if (e.code() != asio::error::operation_aborted) { throw; }
 				is_succeeded = false;
-				log_with_endpoint(log_level::info, param.socket.remote_endpoint(), "Timed out to connect to ",
+				log_with_session(log_level::info, param, "Timed out to connect to ",
 					target_endpoint, ". (", i + 1, "/", try_count, " attempts)");
 			}
 		}
 		socket.close();
 
 		if (is_succeeded) {
-			log_with_endpoint(log_level::info, param.socket.remote_endpoint(), "Connect to ",
+			log_with_session(log_level::info, param, "Connect to ",
 				target_endpoint, " successfully");
 		}
 		else {
-			log_with_endpoint(log_level::info, param.socket.remote_endpoint(), "Failed to connect to ",
+			log_with_session(log_level::info, param, "Failed to connect to ",
 				target_endpoint, ".");
 		}
 
@@ -135,7 +135,7 @@ namespace pgl {
 
 		const auto target_endpoint = asio::ip::tcp::endpoint(
 			param->session_data.remote_endpoint().to_boost_endpoint().address(), message.port_number);
-		log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Start ", message.protocol,
+		log_with_session(log_level::info, param, "Start ", message.protocol,
 			" connectable test to ", target_endpoint, " with setting timeout ",
 			message.protocol == transport_protocol::tcp
 				? param->server_setting.connection_test.connection_check_tcp_time_out_seconds
@@ -163,7 +163,7 @@ namespace pgl {
 			// disconnection by client is expected behavior (asio::error::eof)
 			if (e.code() != asio::error::eof) {
 				reply.succeed = false;
-				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Failed to connect to ",
+				log_with_session(log_level::info, param, "Failed to connect to ",
 					target_endpoint, ": ", e, "");
 			}
 		}

--- a/PlanetaMatchMakerServer/source/message/message_handlers/create_room_request_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/create_room_request_message_handler.cpp
@@ -69,7 +69,7 @@ namespace pgl {
 
 			create_room_reply_message reply{*room_id};
 
-			log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "New ",
+			log_with_session(log_level::info, param, "New ",
 				is_public ? "public" : "private", " room for player \"",
 				param->session_data.client_player_name().generate_full_name(), "\" is created with id: ",
 				reply.room_id);

--- a/PlanetaMatchMakerServer/source/message/message_handlers/join_room_request_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/join_room_request_message_handler.cpp
@@ -55,7 +55,7 @@ namespace pgl {
 				parameter_validator.throw_room_not_found_error(message.room_id);
 		}
 
-		log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Requested room \"", message.room_id,
+		log_with_session(log_level::info, param, "Requested room \"", message.room_id,
 			"\" accepted new player. (", room_data.current_player_count, ").");
 
 		// Reply to the client and Disconnect

--- a/PlanetaMatchMakerServer/source/message/message_handlers/list_room_request_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/list_room_request_message_handler.cpp
@@ -27,7 +27,7 @@ namespace pgl {
 				message.search_full_name);
 			matched_data_list = std::move(search_result.data);
 			total_room_count = search_result.total_room_count;
-			log_with_endpoint(log_level::info, param->socket.remote_endpoint(), matched_data_list.size(),
+			log_with_session(log_level::info, param, matched_data_list.size(),
 				" rooms are matched in ", total_room_count, " rooms.");
 		}
 		catch (out_of_range&) {
@@ -43,7 +43,7 @@ namespace pgl {
 		reply.reply_room_count = std::min(range_checked_static_cast<uint16_t>(
 				reply.matched_room_count <= message.start_index ? 0 : reply.matched_room_count - message.start_index),
 			message.count);
-		log_with_endpoint(log_level::info, param->socket.remote_endpoint(), matched_data_list.size(),
+		log_with_session(log_level::info, param, matched_data_list.size(),
 			" rooms are replied from index ", message.start_index, ".");
 
 		// Generate reply bodies separately
@@ -68,21 +68,21 @@ namespace pgl {
 				else { reply.room_info_list[j] = {}; }
 			}
 
-			log_with_endpoint(log_level::debug, param->socket.remote_endpoint(), "Generate reply body ", i + 1, "/",
+			log_with_session(log_level::debug, param, "Generate reply body ", i + 1, "/",
 				separation,
 				" message.");
 			reply_bodies.push_back(reply);
 		}
 
 		if (separation == 0) {
-			log_with_endpoint(log_level::debug, param->socket.remote_endpoint(),
+			log_with_session(log_level::debug, param,
 				"There are no room which matches request.");
 			reply.reply_room_count = 0;
 			reply.room_info_list = {};
 			reply_bodies.push_back(reply);
 		}
 
-		log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Finished generating reply bodies ",
+		log_with_session(log_level::info, param, "Finished generating reply bodies ",
 			message_type::list_room, " message by ", separation, " messages.");
 
 		return {reply_bodies, false};

--- a/PlanetaMatchMakerServer/source/message/message_handlers/update_room_status_notice_message_handler.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_handlers/update_room_status_notice_message_handler.cpp
@@ -45,7 +45,7 @@ namespace pgl {
 						target_room_data.setting_flags |= room_setting_flag::open_room;
 					});
 				if (!updated_room_data.has_value()) { parameter_validator.throw_room_not_found_error(message.room_id); }
-				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Open ", *updated_room_data, ".");
+				log_with_session(log_level::info, param, "Open ", *updated_room_data, ".");
 				break;
 			case update_room_status_notice_message::status::close:
 				updated_room_data = room_data_container.try_update_with_host_reported_current_player_count(message.room_id,
@@ -56,7 +56,7 @@ namespace pgl {
 						target_room_data.setting_flags &= ~room_setting_flag::open_room;
 					});
 				if (!updated_room_data.has_value()) { parameter_validator.throw_room_not_found_error(message.room_id); }
-				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Close ", *updated_room_data, ".");
+				log_with_session(log_level::info, param, "Close ", *updated_room_data, ".");
 				break;
 			case update_room_status_notice_message::status::remove:
 				updated_room_data = room_data_container.try_remove_if(message.room_id, [&](const auto& target_room_data) {
@@ -65,7 +65,7 @@ namespace pgl {
 					return true;
 				});
 				if (!updated_room_data.has_value()) { parameter_validator.throw_room_not_found_error(message.room_id); }
-				log_with_endpoint(log_level::info, param->socket.remote_endpoint(), "Remove ", *updated_room_data, ".");
+				log_with_session(log_level::info, param, "Remove ", *updated_room_data, ".");
 				param->session_data.delete_hosting_room_id(updated_room_data->room_id);
 				break;
 			default:

--- a/PlanetaMatchMakerServer/source/message/message_parameter_validator.cpp
+++ b/PlanetaMatchMakerServer/source/message/message_parameter_validator.cpp
@@ -16,12 +16,12 @@ namespace pgl {
 	room_data message_parameter_validator::get_existing_room(const room_data_container& room_data_container,
 		const room_id_t room_id, const bool is_continuable) const {
 		if (const auto room_data = room_data_container.try_get(room_id)) {
-			log_with_endpoint(log_level::debug, param_->socket.remote_endpoint(), "The room whose id is \"", room_id,
+			log_with_session(log_level::debug, param_, "The room whose id is \"", room_id,
 				"\" exists.");
 			return *room_data;
 		}
 
-		log_with_endpoint(log_level::error, param_->socket.remote_endpoint(), "The room whose id is \"", room_id,
+		log_with_session(log_level::error, param_, "The room whose id is \"", room_id,
 			"\" doesn't exist.");
 		throw_room_not_found_error(room_id, is_continuable);
 	}

--- a/PlanetaMatchMakerServer/source/server/server_data.cpp
+++ b/PlanetaMatchMakerServer/source/server/server_data.cpp
@@ -11,4 +11,8 @@ namespace pgl {
 	get_room_data_container() { return room_data_container_; }
 
 	player_name_container& server_data::get_player_name_container() { return player_name_container_; }
+
+	session_number_t server_data::issue_session_number() {
+		return next_session_number_.fetch_add(1, std::memory_order_relaxed);
+	}
 }

--- a/PlanetaMatchMakerServer/source/server/server_data.hpp
+++ b/PlanetaMatchMakerServer/source/server/server_data.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <atomic>
+
 #include "room/room_data_container.hpp"
 #include "client/player_name_container.hpp"
+#include "session/session_constants.hpp"
 
 namespace pgl {
 	class server_data final {
@@ -15,7 +18,10 @@ namespace pgl {
 		[[nodiscard]] room_data_container_type& get_room_data_container();
 
 		[[nodiscard]] player_name_container& get_player_name_container();
+
+		[[nodiscard]] session_number_t issue_session_number();
 	private:
+		std::atomic<session_number_t> next_session_number_{1};
 		room_data_container_type room_data_container_;
 		player_name_container player_name_container_;
 	};

--- a/PlanetaMatchMakerServer/source/server/server_session.cpp
+++ b/PlanetaMatchMakerServer/source/server/server_session.cpp
@@ -20,6 +20,18 @@ using namespace boost;
 using namespace minimal_serializer;
 
 namespace pgl {
+	template <typename ... Params>
+	void log_with_session_data_endpoint(const log_level level, const session_data& session_data, Params&& ... params) {
+		if (const auto session_number = session_data.session_number(); session_number.has_value()) {
+			log_with_session_and_endpoint(level, *session_number, session_data.remote_endpoint().to_boost_endpoint(),
+				std::forward<Params>(params)...);
+		}
+		else {
+			log_with_endpoint(level, session_data.remote_endpoint().to_boost_endpoint(),
+				std::forward<Params>(params)...);
+		}
+	}
+
 	server_session::server_session(asio::ip::tcp::acceptor& acceptor, std::mutex& acceptor_mutex,
 		server_data& server_data, const server_setting& server_setting,
 		std::shared_ptr<const message_handler_invoker> message_handler_invoker):
@@ -71,6 +83,7 @@ namespace pgl {
 					shared_this->session_data_->set_remote_endpoint(
 						endpoint::make_from_boost_endpoint(
 							shared_this->socket_.remote_endpoint()));
+					shared_this->session_data_->set_session_number(shared_this->server_data_.issue_session_number());
 				}
 				catch (system::system_error& e) {
 					const auto extra_message = generate_string("Acception failed: ", e, " @",
@@ -78,7 +91,7 @@ namespace pgl {
 					throw server_session_error(extra_message);
 				}
 
-				log_with_endpoint(log_level::info, shared_this->socket_.remote_endpoint(),
+				log_with_session_data_endpoint(log_level::info, *shared_this->session_data_,
 					"Accepted new connection. Start to receive message.");
 
 				// Prepare data
@@ -98,33 +111,32 @@ namespace pgl {
 			}
 			catch (const server_session_intended_disconnect_error& e) {
 				if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
-				log_with_endpoint(log_level::info,
-					shared_this->session_data_->remote_endpoint().to_boost_endpoint(),
+				log_with_session_data_endpoint(log_level::info, *shared_this->session_data_,
 					"Intended disconnect: ", e);
 				shared_this->restart();
 			}
 			catch (const server_session_error& e) {
 				if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
 				// output log as info for session error because it is caused by external factors like disconnection by client and network error.
-				log_with_endpoint(log_level::info, shared_this->session_data_->remote_endpoint().to_boost_endpoint(),
+				log_with_session_data_endpoint(log_level::info, *shared_this->session_data_,
 					e, " Disconnect the connection.");
 				shared_this->restart();
 			}
 			catch (const system::system_error& e) {
 				if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
-				log_with_endpoint(log_level::error, shared_this->session_data_->remote_endpoint().to_boost_endpoint(),
+				log_with_session_data_endpoint(log_level::error, *shared_this->session_data_,
 					"Unhandled error: ", e, " Disconnect the connection: ");
 				shared_this->restart();
 			}
 			catch (const std::exception& e) {
 				if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
-				log_with_endpoint(log_level::error, shared_this->session_data_->remote_endpoint().to_boost_endpoint(),
+				log_with_session_data_endpoint(log_level::error, *shared_this->session_data_,
 					typeid(e), ": ", e.what(), " Disconnect the connection.");
 				shared_this->restart();
 			}
 			catch (...) {
 				if (shared_this->is_stopping_.load(std::memory_order_acquire)) { return; }
-				log_with_endpoint(log_level::fatal, shared_this->session_data_->remote_endpoint().to_boost_endpoint(),
+				log_with_session_data_endpoint(log_level::fatal, *shared_this->session_data_,
 					"Unknown error. Stop the server.");
 				shared_this->stop();
 				throw;
@@ -168,7 +180,10 @@ namespace pgl {
 
 	void server_session::restart() {
 		if (is_stopping_.load(std::memory_order_acquire)) { return; }
-		log(log_level::info, "Server session handler is restarted.");
+		if (session_data_) {
+			log_with_session_data_endpoint(log_level::info, *session_data_, "Server session handler is restarted.");
+		}
+		else { log(log_level::info, "Server session handler is restarted."); }
 		asio::dispatch(strand_, [shared_this = shared_from_this()] {
 			shared_this->stop_impl();
 			shared_this->start_impl();
@@ -178,7 +193,7 @@ namespace pgl {
 	void server_session::remove_hosting_room_if_need(const session_data& session_data) const {
 		if (session_data.is_hosting_room()) {
 			server_data_.get_room_data_container().try_remove(session_data.hosting_room_id());
-			log_with_endpoint(log_level::info, session_data.remote_endpoint().to_boost_endpoint(),
+			log_with_session_data_endpoint(log_level::info, session_data,
 				"Hosting room(ID: ", session_data.hosting_room_id(), ") is removed.");
 		}
 	}
@@ -187,7 +202,7 @@ namespace pgl {
 		if (const auto& player_name_container = server_data_.get_player_name_container(); player_name_container.
 			is_player_exist(session_data.client_player_name())) {
 			server_data_.get_player_name_container().remove_player_name(session_data.client_player_name());
-			log_with_endpoint(log_level::info, session_data.remote_endpoint().to_boost_endpoint(),
+			log_with_session_data_endpoint(log_level::info, session_data,
 				"Player full name(name: ", session_data.client_player_name().name, ", Tag: ",
 				session_data.client_player_name().tag, ") is removed.");
 		}

--- a/PlanetaMatchMakerServer/source/session/session_constants.hpp
+++ b/PlanetaMatchMakerServer/source/session/session_constants.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <cstdint>
+
+namespace pgl {
+	using session_number_t = std::uint64_t;
+}

--- a/PlanetaMatchMakerServer/source/session/session_data.cpp
+++ b/PlanetaMatchMakerServer/source/session/session_data.cpp
@@ -1,6 +1,12 @@
 #include "session/session_data.hpp"
 
 namespace pgl {
+	void session_data::set_session_number(const session_number_t session_number) {
+		if (session_number_.has_value()) { throw std::runtime_error("A session number is already set."); }
+
+		session_number_ = session_number;
+	}
+
 	void session_data::set_hosting_room_id(const room_id_t room_id) {
 		if (is_hosting_room_) { throw std::runtime_error("A hosting room is already set."); }
 
@@ -30,7 +36,7 @@ namespace pgl {
 		is_authenticated_ = true;
 	}
 
-
+	std::optional<session_number_t> session_data::session_number() const { return session_number_; }
 	room_id_t session_data::hosting_room_id() const {
 		if (!is_hosting_room_) { throw std::runtime_error("A hosting room is not set."); }
 

--- a/PlanetaMatchMakerServer/source/session/session_data.hpp
+++ b/PlanetaMatchMakerServer/source/session/session_data.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <optional>
+
 #include "room/room_constants.hpp"
 #include "network/endpoint.hpp"
 #include "client/player_full_name.hpp"
+#include "session_constants.hpp"
 
 namespace pgl {
 	// This class need not be thread safe because one session is processed serially through its session strand.
@@ -10,12 +13,14 @@ namespace pgl {
 	// Each method may throw std::runtime_exception if errors occur.
 	class session_data final {
 	public:
+		void set_session_number(session_number_t session_number);
 		void set_hosting_room_id(room_id_t room_id);
 		void delete_hosting_room_id(room_id_t room_id);
 		void set_remote_endpoint(const endpoint& remote_endpoint);
 		void set_client_player_name(const player_full_name& player_full_name);
 		void set_authenticated();
 
+		[[nodiscard]] std::optional<session_number_t> session_number() const;
 		[[nodiscard]] room_id_t hosting_room_id() const;
 		[[nodiscard]] bool is_hosting_room() const;
 		// use this instead of socket.remote_endpoint() if endpoint information is required after socket is closed because socket.remote_endpoint throws exception in such situation.
@@ -26,6 +31,7 @@ namespace pgl {
 	private:
 		bool is_authenticated_ = false;
 		bool is_hosting_room_ = false;
+		std::optional<session_number_t> session_number_{};
 		room_id_t hosting_room_id_{};
 		endpoint remote_endpoint_{};
 		player_full_name client_player_name_{};

--- a/PlanetaMatchMakerServerTest/PlanetaMatchMakerServerTest.vcxproj
+++ b/PlanetaMatchMakerServerTest/PlanetaMatchMakerServerTest.vcxproj
@@ -74,7 +74,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)obj\$(Platform)\$(Configuration)\PlanetaMatchMakerServer\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>datetime.obj;server_setting.obj;log.obj;network_layer.obj;player_full_name.obj;room_data.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>datetime.obj;server_setting.obj;log.obj;logger_common.obj;network_layer.obj;player_full_name.obj;room_data.obj;server_data.obj;session_data.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -100,19 +100,22 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)obj\$(Platform)\$(Configuration)\PlanetaMatchMakerServer\;$(SolutionDir)obj\$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>datetime.obj;server_setting.obj;log.obj;network_layer.obj;player_full_name.obj;room_data.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>datetime.obj;server_setting.obj;log.obj;logger_common.obj;network_layer.obj;player_full_name.obj;room_data.obj;server_data.obj;session_data.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="checked_static_cast_test.cpp" />
     <ClCompile Include="datetime_test.cpp" />
+    <ClCompile Include="logger_common_test.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="room_data_container_test.cpp" />
     <ClCompile Include="serialize_pack_test.cpp" />
+    <ClCompile Include="server_data_test.cpp" />
     <ClCompile Include="server_setting_test.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
       </ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="session_data_test.cpp" />
     <ClCompile Include="thread_safe_data_container_test.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/PlanetaMatchMakerServerTest/PlanetaMatchMakerServerTest.vcxproj.filters
+++ b/PlanetaMatchMakerServerTest/PlanetaMatchMakerServerTest.vcxproj.filters
@@ -4,9 +4,12 @@
     <ClCompile Include="main.cpp" />
     <ClCompile Include="checked_static_cast_test.cpp" />
     <ClCompile Include="datetime_test.cpp" />
+    <ClCompile Include="logger_common_test.cpp" />
     <ClCompile Include="room_data_container_test.cpp" />
     <ClCompile Include="serialize_pack_test.cpp" />
+    <ClCompile Include="server_data_test.cpp" />
     <ClCompile Include="server_setting_test.cpp" />
+    <ClCompile Include="session_data_test.cpp" />
     <ClCompile Include="thread_safe_data_container_test.cpp" />
   </ItemGroup>
 </Project>

--- a/PlanetaMatchMakerServerTest/logger_common_test.cpp
+++ b/PlanetaMatchMakerServerTest/logger_common_test.cpp
@@ -1,0 +1,22 @@
+#include <boost/test/unit_test.hpp>
+
+#include <sstream>
+#include <string>
+#include <thread>
+
+#include "../PlanetaMatchMakerServer/source/logger/logger_common.hpp"
+
+BOOST_AUTO_TEST_SUITE(logger_common_test)
+	BOOST_AUTO_TEST_CASE(test_output_formatted_log_includes_thread_id) {
+		std::ostringstream out_stream;
+		pgl::output_formatted_log(out_stream, pgl::log_level::info, "", "test message");
+
+		std::ostringstream thread_id_stream;
+		thread_id_stream << std::this_thread::get_id();
+
+		const auto output = out_stream.str();
+		BOOST_CHECK_NE(output.find("[thread:" + thread_id_stream.str() + "]"), std::string::npos);
+		BOOST_CHECK_NE(output.find("info: test message"), std::string::npos);
+	}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/PlanetaMatchMakerServerTest/server_data_test.cpp
+++ b/PlanetaMatchMakerServerTest/server_data_test.cpp
@@ -1,0 +1,14 @@
+#include <boost/test/unit_test.hpp>
+
+#include "../PlanetaMatchMakerServer/source/server/server_data.hpp"
+
+BOOST_AUTO_TEST_SUITE(server_data_test)
+	BOOST_AUTO_TEST_CASE(test_issue_session_number_returns_sequential_values) {
+		pgl::server_data server_data;
+
+		BOOST_CHECK_EQUAL(server_data.issue_session_number(), 1);
+		BOOST_CHECK_EQUAL(server_data.issue_session_number(), 2);
+		BOOST_CHECK_EQUAL(server_data.issue_session_number(), 3);
+	}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/PlanetaMatchMakerServerTest/session_data_test.cpp
+++ b/PlanetaMatchMakerServerTest/session_data_test.cpp
@@ -1,0 +1,31 @@
+#include <boost/test/unit_test.hpp>
+
+#include <stdexcept>
+
+#include "../PlanetaMatchMakerServer/source/session/session_data.hpp"
+
+BOOST_AUTO_TEST_SUITE(session_data_test)
+	BOOST_AUTO_TEST_CASE(test_session_number_is_empty_by_default) {
+		const pgl::session_data session_data;
+
+		BOOST_CHECK(!session_data.session_number().has_value());
+	}
+
+	BOOST_AUTO_TEST_CASE(test_set_session_number_stores_value) {
+		pgl::session_data session_data;
+
+		session_data.set_session_number(42);
+
+		BOOST_REQUIRE(session_data.session_number().has_value());
+		BOOST_CHECK_EQUAL(*session_data.session_number(), 42);
+	}
+
+	BOOST_AUTO_TEST_CASE(test_set_session_number_rejects_reassignment) {
+		pgl::session_data session_data;
+		session_data.set_session_number(42);
+
+		BOOST_CHECK_EXCEPTION(session_data.set_session_number(43), std::runtime_error,
+			[](const auto&) { return true; });
+	}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- Add thread IDs to formatted server log output.
- Add process-local session numbers to accepted connections and include them in session-scoped logs.
- Document the new log fields and add C++ unit tests for logger, server_data, and session_data behavior.

## Impact

Server logs now include `[thread:<id>]` and session-scoped log lines include `[session:<number>]`, making concurrent connection handling easier to trace.

Closes #15

## Validation

- Reviewed staged diff before commit.
- Ran `git diff --cached --check` before commit.
- C++ build/tests were not run locally because `cmake`, `clang++`, and `msbuild` were not available on PATH in this environment.