### PR TITLE
[add] #27 add Unity port mapping release

### DIFF
--- a/Documents/client.md
+++ b/Documents/client.md
@@ -7,5 +7,11 @@ In .Net Framework, port mappings created in the aplication are released automati
 But, in .Net Core, port mappings are not released due to [Open.NAT behavior](https://github.com/lontivero/Open.NAT/issues/94).
 ([This page](https://stackoverflow.com/questions/44732234/why-does-the-finalize-destructor-example-not-work-in-net-core) is also helphul)
 
-Call NatPortMappingCreator.ReleaseCreatedPortMappings method manually to ensure to release port mappings created in the application which uses .Net Core.
+Call NatPortMappingCreator.ReleaseCreatedPortMappingsAsync method manually to ensure to release port mappings created in the application which uses .Net Core.
 (Even if you don'y release them manually, port mappings will be released affer 10 minuites if NAT device suports lifetime of port mapping.)
+
+Unity PlanetaMatchMakerClient releases created port mappings automatically when the component receives OnDestroy if releaseCreatedPortMappingsOnDestroy is true. This option is enabled by default.
+
+The OnDestroy release waits up to 5 seconds. If NAT device doesn't respond in 5 seconds, application quit continues without waiting for the release to finish.
+
+Unity may be unable to call OnDestroy on some platforms or lifecycle paths, such as mobile process kill after suspend or Web platform tab close. Call PlanetaMatchMakerClient.ReleaseCreatedPortMappingsAsync or PlanetaMatchMakerClient.ReleaseCreatedPortMappings manually before those platform-specific exits if required.

--- a/PlanetaMatchMakerClient/Source/Client/MatchMakerClient.cs
+++ b/PlanetaMatchMakerClient/Source/Client/MatchMakerClient.cs
@@ -11,8 +11,8 @@ namespace PlanetaGameLabo.MatchMaker
 {
     /// <summary>
     /// Match maker client.
-    /// Call NatPortMappingCreator.ReleaseCreatedPortMappings method manually to ensure to release port mappings created in the application.
-    /// <see cref="NatPortMappingCreator.ReleaseCreatedPortMappings"/>
+    /// Call NatPortMappingCreator.ReleaseCreatedPortMappingsAsync method manually to ensure to release port mappings created in the application.
+    /// <see cref="NatPortMappingCreator.ReleaseCreatedPortMappingsAsync"/>
     /// </summary>
     public sealed class MatchMakerClient : IDisposable
     {

--- a/PlanetaMatchMakerClient/Source/Client/NatPortMappingCreator.cs
+++ b/PlanetaMatchMakerClient/Source/Client/NatPortMappingCreator.cs
@@ -264,9 +264,9 @@ namespace PlanetaGameLabo.MatchMaker
         /// <summary>
         /// Release created port mappings if exist.
         /// </summary>
-        public static void ReleaseCreatedPortMappings()
+        public static async Task ReleaseCreatedPortMappingsAsync()
         {
-            NatDiscoverer.ReleaseSessionMappings();
+            await NatDiscoverer.ReleaseSessionMappingsAsync().ConfigureAwait(false);
         }
 
         private NatDevice natDevice;

--- a/PlanetaMatchMakerClient/Source/Library/Open.Nat/Finalizer.cs
+++ b/PlanetaMatchMakerClient/Source/Library/Open.Nat/Finalizer.cs
@@ -31,7 +31,7 @@ namespace Open.Nat
 		{
 			NatDiscoverer.TraceSource.LogInfo("Closing ports opened in this session");
 			NatDiscoverer.RenewTimer.Dispose();
-			NatDiscoverer.ReleaseSessionMappings();
+			NatDiscoverer.ReleaseSessionMappingsAsync().GetAwaiter().GetResult();
 		}
 	}
 }

--- a/PlanetaMatchMakerClient/Source/Library/Open.Nat/NatDevice.cs
+++ b/PlanetaMatchMakerClient/Source/Library/Open.Nat/NatDevice.cs
@@ -53,6 +53,7 @@ namespace Open.Nat
 		public abstract IPAddress LocalAddress { get; }
 
 		private readonly HashSet<Mapping> _openedMapping = new HashSet<Mapping>();
+		private readonly object _openedMappingLock = new object();
 		protected DateTime LastSeen { get; private set; }
 
 		internal void Touch()
@@ -120,49 +121,65 @@ namespace Open.Nat
 
 		protected void RegisterMapping(Mapping mapping)
 		{
-			_openedMapping.Remove(mapping);
-			_openedMapping.Add(mapping);
+			lock (_openedMappingLock)
+			{
+				_openedMapping.Remove(mapping);
+				_openedMapping.Add(mapping);
+			}
 		}
 
 		protected void UnregisterMapping(Mapping mapping)
 		{
-			_openedMapping.RemoveWhere(x => x.Equals(mapping));
+			lock (_openedMappingLock)
+			{
+				_openedMapping.RemoveWhere(x => x.Equals(mapping));
+			}
 		}
 
 
-		internal void ReleaseMapping(IEnumerable<Mapping> mappings)
+		internal async Task ReleaseMappingAsync(IEnumerable<Mapping> mappings)
 		{
 			var maparr = mappings.ToArray();
 			var mapCount = maparr.Length;
 			NatDiscoverer.TraceSource.LogInfo("{0} ports to close", mapCount);
-			for (var i = 0; i < mapCount; i++)
+			var tasks = maparr.Select(mapping => Task.Run(async () =>
 			{
-				var mapping = _openedMapping.ElementAt(i);
-
 				try
 				{
-					DeletePortMapAsync(mapping);
+					await DeletePortMapAsync(mapping).ConfigureAwait(false);
 					NatDiscoverer.TraceSource.LogInfo(mapping + " port successfully closed");
 				}
 				catch (Exception)
 				{
 					NatDiscoverer.TraceSource.LogError(mapping + " port couldn't be close");
 				}
+			})).ToArray();
+			await Task.WhenAll(tasks).ConfigureAwait(false);
+		}
+
+		internal async Task ReleaseAllAsync()
+		{
+			Mapping[] mappings;
+			lock (_openedMappingLock)
+			{
+				mappings = _openedMapping.ToArray();
 			}
+
+			await ReleaseMappingAsync(mappings).ConfigureAwait(false);
 		}
 
-		internal void ReleaseAll()
+		internal async Task ReleaseSessionMappingsAsync()
 		{
-			ReleaseMapping(_openedMapping);
-		}
+			Mapping[] mappings;
+			lock (_openedMappingLock)
+			{
+				mappings = (from m in _openedMapping
+							where m.LifetimeType == MappingLifetime.Session ||
+								  m.LifetimeType == MappingLifetime.ForcedSession
+							select m).ToArray();
+			}
 
-		internal void ReleaseSessionMappings()
-		{
-			var mappings = from m in _openedMapping
-						   where m.LifetimeType == MappingLifetime.Session
-						   select m;
-
-			ReleaseMapping(mappings);
+			await ReleaseMappingAsync(mappings).ConfigureAwait(false);
 		}
 
 		internal async Task RenewMappings()

--- a/PlanetaMatchMakerClient/Source/Library/Open.Nat/NatDevice.cs
+++ b/PlanetaMatchMakerClient/Source/Library/Open.Nat/NatDevice.cs
@@ -142,7 +142,7 @@ namespace Open.Nat
 			var maparr = mappings.ToArray();
 			var mapCount = maparr.Length;
 			NatDiscoverer.TraceSource.LogInfo("{0} ports to close", mapCount);
-			var tasks = maparr.Select(mapping => Task.Run(async () =>
+			var tasks = maparr.Select(async mapping =>
 			{
 				try
 				{
@@ -153,7 +153,7 @@ namespace Open.Nat
 				{
 					NatDiscoverer.TraceSource.LogError(mapping + " port couldn't be close");
 				}
-			})).ToArray();
+			}).ToArray();
 			await Task.WhenAll(tasks).ConfigureAwait(false);
 		}
 
@@ -184,8 +184,13 @@ namespace Open.Nat
 
 		internal async Task RenewMappings()
 		{
-			var mappings = _openedMapping.Where(x => x.ShoundRenew());
-			foreach (var mapping in mappings.ToArray())
+			Mapping[] mappings;
+			lock (_openedMappingLock)
+			{
+				mappings = _openedMapping.Where(x => x.ShoundRenew()).ToArray();
+			}
+
+			foreach (var mapping in mappings)
 			{
 				var m = mapping;
 				await RenewMapping(m);

--- a/PlanetaMatchMakerClient/Source/Library/Open.Nat/NatDiscoverer.cs
+++ b/PlanetaMatchMakerClient/Source/Library/Open.Nat/NatDiscoverer.cs
@@ -126,20 +126,20 @@ namespace Open.Nat
 		/// <remarks>
 		/// If ReleaseOnShutdown value is true, it release all the mappings created through the library.
 		/// </remarks>
-		public static void ReleaseAll()
+		public static async Task ReleaseAllAsync()
 		{
-			foreach (var device in Devices.Values)
-			{
-				device.ReleaseAll();
-			}
+			var tasks = Devices.Values.ToArray()
+				.Select(device => device.ReleaseAllAsync())
+				.ToArray();
+			await Task.WhenAll(tasks).ConfigureAwait(false);
 		}
 
-		internal static void ReleaseSessionMappings()
+		internal static async Task ReleaseSessionMappingsAsync()
 		{
-			foreach (var device in Devices.Values)
-			{
-				device.ReleaseSessionMappings();
-			}
+			var tasks = Devices.Values.ToArray()
+				.Select(device => device.ReleaseSessionMappingsAsync())
+				.ToArray();
+			await Task.WhenAll(tasks).ConfigureAwait(false);
 		}
 
 		private static void RenewMappings(object state)

--- a/PlanetaMatchMakerClient/Source/Library/Open.Nat/PATCHES.md
+++ b/PlanetaMatchMakerClient/Source/Library/Open.Nat/PATCHES.md
@@ -38,7 +38,7 @@ The following release fixes are maintained locally:
 - Release APIs are task-based so callers can wait for port mapping deletion to finish.
 - Release uses a snapshot of the target mappings and deletes those exact mappings.
 - Multiple mappings are deleted in parallel to avoid shutdown time increasing linearly with mapping count.
-- Opened mapping registration and removal are guarded by a lock.
+- Opened mapping registration, removal, release snapshots, and renewal snapshots are guarded by a lock.
 - Forced session mappings are included in session release, because they are created only as a fallback for routers that accept permanent leases but still need application-session cleanup.
 
 Related tests are in `PlanetaMatchMakerClientTest/Source/OpenNatReleaseTest.cs`.

--- a/PlanetaMatchMakerClient/Source/Library/Open.Nat/PATCHES.md
+++ b/PlanetaMatchMakerClient/Source/Library/Open.Nat/PATCHES.md
@@ -29,6 +29,20 @@ The vendored code is maintained only for the current Planeta Match Maker client 
 - Removed legacy .NET 3.5 compatibility branches and helper types.
 - Removed NAT-PMP discovery and port mapping support. NAT-PMP-capable home routers are uncommon enough that the maintenance and security review cost is larger than the expected benefit for this project.
 
+### Port mapping release reliability
+
+Open.NAT's original shutdown release path did not await `DeletePortMapAsync` and could release the wrong mapping because it iterated a filtered snapshot but deleted by indexing into the live opened-mapping set.
+
+The following release fixes are maintained locally:
+
+- Release APIs are task-based so callers can wait for port mapping deletion to finish.
+- Release uses a snapshot of the target mappings and deletes those exact mappings.
+- Multiple mappings are deleted in parallel to avoid shutdown time increasing linearly with mapping count.
+- Opened mapping registration and removal are guarded by a lock.
+- Forced session mappings are included in session release, because they are created only as a fallback for routers that accept permanent leases but still need application-session cleanup.
+
+Related tests are in `PlanetaMatchMakerClientTest/Source/OpenNatReleaseTest.cs`.
+
 ### UPnP response and request hardening
 
 UPnP is used only by clients that explicitly create NAT port mappings. The match-making server does not expose a UPnP service.

--- a/PlanetaMatchMakerClientTest/Source/OpenNatReleaseTest.cs
+++ b/PlanetaMatchMakerClientTest/Source/OpenNatReleaseTest.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Open.Nat;
+
+namespace PlanetaMatchMakerClientTest
+{
+    [TestClass]
+    public class OpenNatReleaseTest
+    {
+        [TestMethod]
+        public async Task ReleaseSessionMappingsAsyncDeletesOnlySessionMappings()
+        {
+            var device = new TestNatDevice();
+            var permanentMapping = CreateMapping(Protocol.Tcp, 1000, 2000, 0);
+            var manualMapping = CreateMapping(Protocol.Tcp, 1001, 2001, 60);
+            var sessionMapping = CreateMapping(Protocol.Tcp, 1002, 2002, int.MaxValue);
+            var forcedSessionMapping = CreateMapping(Protocol.Udp, 1003, 2003, int.MaxValue);
+            forcedSessionMapping.LifetimeType = MappingLifetime.ForcedSession;
+
+            device.AddOpenedMapping(permanentMapping);
+            device.AddOpenedMapping(manualMapping);
+            device.AddOpenedMapping(sessionMapping);
+            device.AddOpenedMapping(forcedSessionMapping);
+
+            await device.ReleaseSessionMappingsAsync();
+
+            CollectionAssert.AreEquivalent(
+                new[] { 2002, 2003 },
+                device.DeletedMappings.Select(mapping => mapping.PublicPort).ToArray());
+        }
+
+        [TestMethod]
+        public async Task ReleaseSessionMappingsAsyncWaitsForDeleteCompletion()
+        {
+            var device = new TestNatDevice { ExpectedDeleteCount = 1 };
+            var deleteGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            device.DeleteGate = deleteGate;
+            device.AddOpenedMapping(CreateMapping(Protocol.Tcp, 1000, 2000, int.MaxValue));
+
+            var releaseTask = device.ReleaseSessionMappingsAsync();
+            await device.AllExpectedDeletesStarted;
+
+            Assert.IsFalse(releaseTask.IsCompleted);
+            deleteGate.SetResult(true);
+            await releaseTask;
+
+            Assert.IsTrue(releaseTask.IsCompleted);
+        }
+
+        [TestMethod]
+        public async Task ReleaseSessionMappingsAsyncStartsDeletesInParallel()
+        {
+            var device = new TestNatDevice { ExpectedDeleteCount = 2 };
+            var deleteGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            device.DeleteGate = deleteGate;
+            device.AddOpenedMapping(CreateMapping(Protocol.Tcp, 1000, 2000, 0));
+            device.AddOpenedMapping(CreateMapping(Protocol.Tcp, 1001, 2001, int.MaxValue));
+            device.AddOpenedMapping(CreateMapping(Protocol.Udp, 1002, 2002, int.MaxValue));
+
+            var releaseTask = device.ReleaseSessionMappingsAsync();
+            var completedTask = await Task.WhenAny(device.AllExpectedDeletesStarted, Task.Delay(1000));
+
+            Assert.AreSame(device.AllExpectedDeletesStarted, completedTask);
+            Assert.IsFalse(releaseTask.IsCompleted);
+            CollectionAssert.AreEquivalent(
+                new[] { 2001, 2002 },
+                device.DeletedMappings.Select(mapping => mapping.PublicPort).ToArray());
+
+            deleteGate.SetResult(true);
+            await releaseTask;
+        }
+
+        private static Mapping CreateMapping(Protocol protocol, int privatePort, int publicPort, int lifetime)
+        {
+            return new Mapping(
+                protocol,
+                IPAddress.Parse("192.168.1.2"),
+                privatePort,
+                publicPort,
+                lifetime,
+                "PlanetaMatchMakerClientTest");
+        }
+
+        private sealed class TestNatDevice : NatDevice
+        {
+            private readonly object syncObject = new object();
+            private readonly TaskCompletionSource<bool> allExpectedDeletesStarted =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public override IPEndPoint HostEndPoint { get; } =
+                new IPEndPoint(IPAddress.Parse("192.168.1.1"), 1900);
+
+            public override IPAddress LocalAddress { get; } = IPAddress.Parse("192.168.1.2");
+
+            public List<Mapping> DeletedMappings { get; } = new List<Mapping>();
+
+            public int ExpectedDeleteCount { get; set; }
+
+            public TaskCompletionSource<bool> DeleteGate { get; set; }
+
+            public Task AllExpectedDeletesStarted => allExpectedDeletesStarted.Task;
+
+            public void AddOpenedMapping(Mapping mapping)
+            {
+                RegisterMapping(mapping);
+            }
+
+            public override Task CreatePortMapAsync(Mapping mapping)
+            {
+                RegisterMapping(mapping);
+                return Task.CompletedTask;
+            }
+
+            public override async Task DeletePortMapAsync(Mapping mapping)
+            {
+                lock (syncObject)
+                {
+                    DeletedMappings.Add(mapping);
+                    if (ExpectedDeleteCount == 0 || DeletedMappings.Count == ExpectedDeleteCount)
+                    {
+                        allExpectedDeletesStarted.TrySetResult(true);
+                    }
+                }
+
+                if (DeleteGate != null)
+                {
+                    await DeleteGate.Task.ConfigureAwait(false);
+                }
+
+                UnregisterMapping(mapping);
+            }
+
+            public override Task<IEnumerable<Mapping>> GetAllMappingsAsync()
+            {
+                return Task.FromResult(Enumerable.Empty<Mapping>());
+            }
+
+            public override Task<IPAddress> GetExternalIPAsync()
+            {
+                return Task.FromResult(IPAddress.Parse("203.0.113.1"));
+            }
+
+            public override Task<Mapping> GetSpecificMappingAsync(Protocol protocol, int port)
+            {
+                return Task.FromResult<Mapping>(null);
+            }
+        }
+    }
+}

--- a/PlanetaMatchMakerTestClient/Command/CommandExecutors/ReleasePortMappingsCommandExecutor.cs
+++ b/PlanetaMatchMakerTestClient/Command/CommandExecutors/ReleasePortMappingsCommandExecutor.cs
@@ -17,7 +17,7 @@ namespace PlanetaGameLabo.MatchMaker
             StandardCommandOptions options,
             CancellationToken cancellationToken)
         {
-            NatPortMappingCreator.ReleaseCreatedPortMappings();
+            await NatPortMappingCreator.ReleaseCreatedPortMappingsAsync();
             OutputStream.WriteLine("Port mappings are released.");
             OutputStream.WriteLine("Note: this command doesn't check errors.");
         }

--- a/PlanetaMatchMakerTestClient/Command/CommandExecutors/TestAllCommandExecutor.cs
+++ b/PlanetaMatchMakerTestClient/Command/CommandExecutors/TestAllCommandExecutor.cs
@@ -114,10 +114,7 @@ namespace PlanetaGameLabo.MatchMaker
         private async Task RemovePortMappings(MatchMakerClient sharedClient, TestAllCommandOptions options,
             CancellationToken cancellationToken)
         {
-            NatPortMappingCreator.ReleaseCreatedPortMappings();
-            // We wait 1 second because it is possible that removing port mappings is not finished just after the operation.
-            OutputStream.WriteLine("Wait 1 second.");
-            await Task.Delay(1000, cancellationToken);
+            await NatPortMappingCreator.ReleaseCreatedPortMappingsAsync();
         }
 
         private async Task ListPortMappingsAndCheckRemoved(MatchMakerClient sharedClient, TestAllCommandOptions options,

--- a/PlanetaMatchMakerTestClient/Main/Program.cs
+++ b/PlanetaMatchMakerTestClient/Main/Program.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using CommandLine.Text;
 
 namespace PlanetaGameLabo.MatchMaker
 {
     internal static class Program
     {
-        private static void Main(string[] args)
+        private static async Task Main(string[] args)
         {
             var versionInfo =
                 FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location);
@@ -79,7 +80,7 @@ namespace PlanetaGameLabo.MatchMaker
             }
             finally
             {
-                NatPortMappingCreator.ReleaseCreatedPortMappings();
+                await NatPortMappingCreator.ReleaseCreatedPortMappingsAsync();
             }
         }
 

--- a/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/Examples/MatchMakerClient.prefab
+++ b/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/Examples/MatchMakerClient.prefab
@@ -58,6 +58,7 @@ MonoBehaviour:
   - _startPort: 50000
     _endPort: 56000
   _natDiscoverTimeOutSeconds: 5
+  _releaseCreatedPortMappingsOnDestroy: 1
   _enableDebugLog: 1
   _debugLogLevel: 0
 --- !u!114 &4546133711901321005

--- a/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Client/MatchMakerClient.cs
+++ b/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Client/MatchMakerClient.cs
@@ -11,8 +11,8 @@ namespace PlanetaGameLabo.MatchMaker
 {
     /// <summary>
     /// Match maker client.
-    /// Call NatPortMappingCreator.ReleaseCreatedPortMappings method manually to ensure to release port mappings created in the application.
-    /// <see cref="NatPortMappingCreator.ReleaseCreatedPortMappings"/>
+    /// Call NatPortMappingCreator.ReleaseCreatedPortMappingsAsync method manually to ensure to release port mappings created in the application.
+    /// <see cref="NatPortMappingCreator.ReleaseCreatedPortMappingsAsync"/>
     /// </summary>
     public sealed class MatchMakerClient : IDisposable
     {

--- a/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Client/NatPortMappingCreator.cs
+++ b/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Client/NatPortMappingCreator.cs
@@ -264,9 +264,9 @@ namespace PlanetaGameLabo.MatchMaker
         /// <summary>
         /// Release created port mappings if exist.
         /// </summary>
-        public static void ReleaseCreatedPortMappings()
+        public static async Task ReleaseCreatedPortMappingsAsync()
         {
-            NatDiscoverer.ReleaseSessionMappings();
+            await NatDiscoverer.ReleaseSessionMappingsAsync().ConfigureAwait(false);
         }
 
         private NatDevice natDevice;

--- a/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/Finalizer.cs
+++ b/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/Finalizer.cs
@@ -31,7 +31,7 @@ namespace Open.Nat
 		{
 			NatDiscoverer.TraceSource.LogInfo("Closing ports opened in this session");
 			NatDiscoverer.RenewTimer.Dispose();
-			NatDiscoverer.ReleaseSessionMappings();
+			NatDiscoverer.ReleaseSessionMappingsAsync().GetAwaiter().GetResult();
 		}
 	}
 }

--- a/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/NatDevice.cs
+++ b/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/NatDevice.cs
@@ -53,6 +53,7 @@ namespace Open.Nat
 		public abstract IPAddress LocalAddress { get; }
 
 		private readonly HashSet<Mapping> _openedMapping = new HashSet<Mapping>();
+		private readonly object _openedMappingLock = new object();
 		protected DateTime LastSeen { get; private set; }
 
 		internal void Touch()
@@ -120,49 +121,65 @@ namespace Open.Nat
 
 		protected void RegisterMapping(Mapping mapping)
 		{
-			_openedMapping.Remove(mapping);
-			_openedMapping.Add(mapping);
+			lock (_openedMappingLock)
+			{
+				_openedMapping.Remove(mapping);
+				_openedMapping.Add(mapping);
+			}
 		}
 
 		protected void UnregisterMapping(Mapping mapping)
 		{
-			_openedMapping.RemoveWhere(x => x.Equals(mapping));
+			lock (_openedMappingLock)
+			{
+				_openedMapping.RemoveWhere(x => x.Equals(mapping));
+			}
 		}
 
 
-		internal void ReleaseMapping(IEnumerable<Mapping> mappings)
+		internal async Task ReleaseMappingAsync(IEnumerable<Mapping> mappings)
 		{
 			var maparr = mappings.ToArray();
 			var mapCount = maparr.Length;
 			NatDiscoverer.TraceSource.LogInfo("{0} ports to close", mapCount);
-			for (var i = 0; i < mapCount; i++)
+			var tasks = maparr.Select(mapping => Task.Run(async () =>
 			{
-				var mapping = _openedMapping.ElementAt(i);
-
 				try
 				{
-					DeletePortMapAsync(mapping);
+					await DeletePortMapAsync(mapping).ConfigureAwait(false);
 					NatDiscoverer.TraceSource.LogInfo(mapping + " port successfully closed");
 				}
 				catch (Exception)
 				{
 					NatDiscoverer.TraceSource.LogError(mapping + " port couldn't be close");
 				}
+			})).ToArray();
+			await Task.WhenAll(tasks).ConfigureAwait(false);
+		}
+
+		internal async Task ReleaseAllAsync()
+		{
+			Mapping[] mappings;
+			lock (_openedMappingLock)
+			{
+				mappings = _openedMapping.ToArray();
 			}
+
+			await ReleaseMappingAsync(mappings).ConfigureAwait(false);
 		}
 
-		internal void ReleaseAll()
+		internal async Task ReleaseSessionMappingsAsync()
 		{
-			ReleaseMapping(_openedMapping);
-		}
+			Mapping[] mappings;
+			lock (_openedMappingLock)
+			{
+				mappings = (from m in _openedMapping
+							where m.LifetimeType == MappingLifetime.Session ||
+								  m.LifetimeType == MappingLifetime.ForcedSession
+							select m).ToArray();
+			}
 
-		internal void ReleaseSessionMappings()
-		{
-			var mappings = from m in _openedMapping
-						   where m.LifetimeType == MappingLifetime.Session
-						   select m;
-
-			ReleaseMapping(mappings);
+			await ReleaseMappingAsync(mappings).ConfigureAwait(false);
 		}
 
 		internal async Task RenewMappings()

--- a/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/NatDevice.cs
+++ b/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/NatDevice.cs
@@ -142,7 +142,7 @@ namespace Open.Nat
 			var maparr = mappings.ToArray();
 			var mapCount = maparr.Length;
 			NatDiscoverer.TraceSource.LogInfo("{0} ports to close", mapCount);
-			var tasks = maparr.Select(mapping => Task.Run(async () =>
+			var tasks = maparr.Select(async mapping =>
 			{
 				try
 				{
@@ -153,7 +153,7 @@ namespace Open.Nat
 				{
 					NatDiscoverer.TraceSource.LogError(mapping + " port couldn't be close");
 				}
-			})).ToArray();
+			}).ToArray();
 			await Task.WhenAll(tasks).ConfigureAwait(false);
 		}
 
@@ -184,8 +184,13 @@ namespace Open.Nat
 
 		internal async Task RenewMappings()
 		{
-			var mappings = _openedMapping.Where(x => x.ShoundRenew());
-			foreach (var mapping in mappings.ToArray())
+			Mapping[] mappings;
+			lock (_openedMappingLock)
+			{
+				mappings = _openedMapping.Where(x => x.ShoundRenew()).ToArray();
+			}
+
+			foreach (var mapping in mappings)
 			{
 				var m = mapping;
 				await RenewMapping(m);

--- a/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/NatDiscoverer.cs
+++ b/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/NatDiscoverer.cs
@@ -126,20 +126,20 @@ namespace Open.Nat
 		/// <remarks>
 		/// If ReleaseOnShutdown value is true, it release all the mappings created through the library.
 		/// </remarks>
-		public static void ReleaseAll()
+		public static async Task ReleaseAllAsync()
 		{
-			foreach (var device in Devices.Values)
-			{
-				device.ReleaseAll();
-			}
+			var tasks = Devices.Values.ToArray()
+				.Select(device => device.ReleaseAllAsync())
+				.ToArray();
+			await Task.WhenAll(tasks).ConfigureAwait(false);
 		}
 
-		internal static void ReleaseSessionMappings()
+		internal static async Task ReleaseSessionMappingsAsync()
 		{
-			foreach (var device in Devices.Values)
-			{
-				device.ReleaseSessionMappings();
-			}
+			var tasks = Devices.Values.ToArray()
+				.Select(device => device.ReleaseSessionMappingsAsync())
+				.ToArray();
+			await Task.WhenAll(tasks).ConfigureAwait(false);
 		}
 
 		private static void RenewMappings(object state)

--- a/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/PATCHES.md
+++ b/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/PATCHES.md
@@ -38,7 +38,7 @@ The following release fixes are maintained locally:
 - Release APIs are task-based so callers can wait for port mapping deletion to finish.
 - Release uses a snapshot of the target mappings and deletes those exact mappings.
 - Multiple mappings are deleted in parallel to avoid shutdown time increasing linearly with mapping count.
-- Opened mapping registration and removal are guarded by a lock.
+- Opened mapping registration, removal, release snapshots, and renewal snapshots are guarded by a lock.
 - Forced session mappings are included in session release, because they are created only as a fallback for routers that accept permanent leases but still need application-session cleanup.
 
 Related tests are in `PlanetaMatchMakerClientTest/Source/OpenNatReleaseTest.cs`.

--- a/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/PATCHES.md
+++ b/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/PlanetaMatchMakerClient/Library/Open.Nat/PATCHES.md
@@ -29,6 +29,20 @@ The vendored code is maintained only for the current Planeta Match Maker client 
 - Removed legacy .NET 3.5 compatibility branches and helper types.
 - Removed NAT-PMP discovery and port mapping support. NAT-PMP-capable home routers are uncommon enough that the maintenance and security review cost is larger than the expected benefit for this project.
 
+### Port mapping release reliability
+
+Open.NAT's original shutdown release path did not await `DeletePortMapAsync` and could release the wrong mapping because it iterated a filtered snapshot but deleted by indexing into the live opened-mapping set.
+
+The following release fixes are maintained locally:
+
+- Release APIs are task-based so callers can wait for port mapping deletion to finish.
+- Release uses a snapshot of the target mappings and deletes those exact mappings.
+- Multiple mappings are deleted in parallel to avoid shutdown time increasing linearly with mapping count.
+- Opened mapping registration and removal are guarded by a lock.
+- Forced session mappings are included in session release, because they are created only as a fallback for routers that accept permanent leases but still need application-session cleanup.
+
+Related tests are in `PlanetaMatchMakerClientTest/Source/OpenNatReleaseTest.cs`.
+
 ### UPnP response and request hardening
 
 UPnP is used only by clients that explicitly create NAT port mappings. The match-making server does not expose a UPnP service.

--- a/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/Runtime/PlanetaMatchMakerClient.cs
+++ b/PlanetaMatchMakerUnityClient/Assets/PlanetaGameLabo/MatchMaker/Runtime/PlanetaMatchMakerClient.cs
@@ -158,6 +158,15 @@ namespace PlanetaGameLabo.MatchMaker
         }
 
         /// <summary>
+        /// true if port mappings created by this application are released when this component is destroyed.
+        /// </summary>
+        public bool releaseCreatedPortMappingsOnDestroy
+        {
+            get => _releaseCreatedPortMappingsOnDestroy;
+            set => _releaseCreatedPortMappingsOnDestroy = value;
+        }
+
+        /// <summary>
         /// A hosting room information.
         /// This is valid when the client is hosting room.
         /// </summary>
@@ -616,6 +625,25 @@ namespace PlanetaGameLabo.MatchMaker
             }
         }
 
+        /// <summary>
+        /// Release port mappings created by this application.
+        /// </summary>
+        /// <param name="callback"></param>
+        public void ReleaseCreatedPortMappings(Action<ErrorInfo> callback = null)
+        {
+            RunTask(ReleaseCreatedPortMappingsAsync, callback);
+        }
+
+        /// <summary>
+        /// Release port mappings created by this application.
+        /// </summary>
+        public async Task<ErrorInfo> ReleaseCreatedPortMappingsAsync()
+        {
+            return await RunTaskWithErrorHandlingAsync(
+                async () => await NatPortMappingCreator.ReleaseCreatedPortMappingsAsync(),
+                () => { });
+        }
+
         #endregion
 
         #region OtherPublicMethods
@@ -647,6 +675,8 @@ namespace PlanetaGameLabo.MatchMaker
         #endregion
 
         #region PrivateFields
+
+        private const int ReleaseCreatedPortMappingsOnDestroyTimeoutMilliSeconds = 5000;
 
         [SerializeField, Tooltip("Don't destroy the game object which is attached this component on load if true")]
         private bool _dontDestroyOnLoad;
@@ -684,6 +714,9 @@ namespace PlanetaGameLabo.MatchMaker
 
         [SerializeField, Tooltip("Timeout seconds to discover NAT device")]
         private float _natDiscoverTimeOutSeconds = 5;
+
+        [SerializeField, Tooltip("Release port mappings created by this application when this component is destroyed if true")]
+        private bool _releaseCreatedPortMappingsOnDestroy = true;
 
         private MatchMakerClient _client;
         private Status _status = Status.Disconnected;
@@ -726,6 +759,7 @@ namespace PlanetaGameLabo.MatchMaker
 
         private void OnDestroy()
         {
+            ReleaseCreatedPortMappingsOnDestroy();
             _client.Dispose();
 
             if (!_isSingleton)
@@ -929,6 +963,37 @@ namespace PlanetaGameLabo.MatchMaker
         {
             status = Status.Disconnected;
             _hostingRoomInfo = null;
+        }
+
+        private void ReleaseCreatedPortMappingsOnDestroy()
+        {
+            if (!_releaseCreatedPortMappingsOnDestroy)
+            {
+                return;
+            }
+
+            if (_isSingleton && singleton != this)
+            {
+                return;
+            }
+
+            try
+            {
+                var releaseTask = Task.Run(async () =>
+                    await NatPortMappingCreator.ReleaseCreatedPortMappingsAsync().ConfigureAwait(false));
+                if (!releaseTask.Wait(ReleaseCreatedPortMappingsOnDestroyTimeoutMilliSeconds))
+                {
+                    Debug.LogWarning("Timed out releasing port mappings created by this application.");
+                }
+            }
+            catch (AggregateException e)
+            {
+                Debug.LogException(e.InnerException ?? e);
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
         }
 
         #endregion


### PR DESCRIPTION
## Summary

- Add async port mapping release APIs and update existing callers to await them.
- Release Unity-created port mappings automatically from PlanetaMatchMakerClient.OnDestroy with a 5 second shutdown wait limit.
- Fix bundled Open.NAT release behavior so session mappings are released by snapshot, awaited, and deleted in parallel.
- Document the bundled Open.NAT patch and Unity lifecycle limitations.

Closes #27

## Validation

- dotnet test PlanetaMatchMakerClientTest -c Release --no-restore
- dotnet build PlanetaMatchMakerTestClient -c Release
- git diff --check

Notes: validation still reports existing NU1900 package vulnerability metadata warnings when NuGet vulnerability data cannot be fetched, and existing analyzer warnings from the client project.